### PR TITLE
新增{originaltitle}和修复{title}的共享目录限制

### DIFF
--- a/packages/shared/assetNaming.ts
+++ b/packages/shared/assetNaming.ts
@@ -1,5 +1,6 @@
 export const ASSET_NAMING_MODES = ["fixed", "followVideo"] as const;
 export const MOVIE_NFO_BASE_NAME = "movie";
+const DEDICATED_MOVIE_DIRECTORY_PLACEHOLDERS = ["{number}", "{title}", "{originaltitle}"] as const;
 
 export type AssetNamingMode = (typeof ASSET_NAMING_MODES)[number];
 export type MovieAssetKind = "thumb" | "poster" | "fanart" | "trailer";
@@ -19,7 +20,12 @@ const FIXED_MOVIE_ASSET_FILE_NAMES: MovieAssetFileNames = {
 };
 
 export const isSharedDirectoryMode = (input: { successFileMove: boolean; folderTemplate: string }): boolean => {
-  return input.successFileMove && !input.folderTemplate.includes("{number}");
+  if (!input.successFileMove) {
+    return false;
+  }
+
+  const normalizedTemplate = input.folderTemplate.toLowerCase();
+  return !DEDICATED_MOVIE_DIRECTORY_PLACEHOLDERS.some((placeholder) => normalizedTemplate.includes(placeholder));
 };
 
 export const isMovieNfoBaseName = (value: string): boolean => value.trim().toLowerCase() === MOVIE_NFO_BASE_NAME;

--- a/src/main/services/crawler/sites/dmm/dmm_tv.ts
+++ b/src/main/services/crawler/sites/dmm/dmm_tv.ts
@@ -1,27 +1,45 @@
 import { toErrorMessage } from "@main/utils/common";
 import { Website } from "@shared/enums";
 import type { CrawlerData } from "@shared/types";
-import type { CheerioAPI } from "cheerio";
+import { type CheerioAPI, load } from "cheerio";
 
 import type { Context, CrawlerInput, SearchPageResolution } from "../../base/types";
 import type { FetchOptions } from "../../FetchGateway";
 import type { CrawlerRegistration } from "../../registration";
-import { toAbsoluteUrl } from "../helpers";
+import { toAbsoluteUrl, uniqueStrings } from "../helpers";
 import { BaseDmmCrawler } from "./BaseDmmCrawler";
 import { normalizeContentIds } from "./contentId";
 import { parseDigitalDetail } from "./parsers";
 
 interface DmmTvContext extends Context {
   candidateIds: string[];
+  searchTerms: string[];
 }
 
 const DMM_VIDEO_BASE = "https://video.dmm.co.jp";
 const DMM_VIDEO_GRAPHQL_ENDPOINT = "https://api.video.dmm.co.jp/graphql";
+const DMM_VIDEO_DETAIL_PATHS = ["/av/content/?id=", "/anime/content/?id="] as const;
+
+type DmmVideoDetailPath = (typeof DMM_VIDEO_DETAIL_PATHS)[number];
 
 interface DmmVideoPayload {
   operationName: string;
   query: string;
-  variables: Record<string, string>;
+  variables: Record<string, unknown>;
+}
+
+interface DmmVideoSearchPayload {
+  operationName: string;
+  query: string;
+  variables: {
+    limit: number;
+    offset: number;
+    floor: "AV" | "ANIME";
+    sort: "SALES_RANK_SCORE";
+    queryWord: string;
+    facetLimit: number;
+    excludeUndelivered: boolean;
+  };
 }
 
 interface DmmVideoDataResponse {
@@ -38,6 +56,14 @@ interface DmmVideoDataResponse {
     maker?: { name?: string };
     label?: { name?: string };
     genres?: Array<{ name?: string }>;
+    relatedTags?: Array<
+      | {
+          tags?: Array<{ name?: string }>;
+        }
+      | {
+          name?: string;
+        }
+    >;
     packageImage?: { largeUrl?: string; mediumUrl?: string };
     sampleImages?: Array<{ largeImageUrl?: string }>;
     sample2DMovie?: { highestMovieUrl?: string; hlsMovieUrl?: string };
@@ -45,15 +71,86 @@ interface DmmVideoDataResponse {
   reviewSummary?: { average?: number };
 }
 
-const CONTENT_PAGE_DATA_QUERY =
-  "query ContentPageData($id: ID!) { ppvContent(id: $id) { title description makerContentId makerReleasedAt deliveryStartDate duration packageImage { largeUrl mediumUrl } sampleImages { largeImageUrl } sample2DMovie { highestMovieUrl hlsMovieUrl } actresses { name } directors { name } series { name } maker { name } label { name } genres { name } } reviewSummary(contentId: $id) { average } }";
+interface DmmVideoSearchResponse {
+  legacySearchPPV?: {
+    result?: {
+      contents?: Array<{
+        id?: string;
+        title?: string;
+        contentType?: string;
+      }>;
+    };
+  };
+}
 
-const buildDetailUrl = (contentId: string): string => `${DMM_VIDEO_BASE}/av/content/?id=${contentId}`;
+const CONTENT_PAGE_DATA_QUERY =
+  "query ContentPageData($id: ID!, $shouldFetchRelatedTags: Boolean = true) { ppvContent(id: $id) { title description makerContentId makerReleasedAt deliveryStartDate duration packageImage { largeUrl mediumUrl } sampleImages { largeImageUrl } sample2DMovie { highestMovieUrl hlsMovieUrl } actresses { name } directors { name } series { name } maker { name } label { name } genres { name } relatedTags(limit: 16) @include(if: $shouldFetchRelatedTags) { ... on ContentTagGroup { tags { name } } ... on ContentTag { name } } } reviewSummary(contentId: $id) { average } }";
+
+const AV_SEARCH_QUERY =
+  "query AvSearch($limit: Int!, $offset: Int, $floor: PPVFloor, $sort: ContentSearchPPVSort!, $queryWord: String, $facetLimit: Int!, $excludeUndelivered: Boolean!) { legacySearchPPV(limit: $limit, offset: $offset, floor: $floor, sort: $sort, queryWord: $queryWord, facetLimit: $facetLimit, includeExplicit: true, excludeUndelivered: $excludeUndelivered) { result { contents { id title contentType } } } }";
+
+const ANIME_SEARCH_QUERY =
+  "query AnimeSearch($limit: Int!, $offset: Int, $floor: PPVFloor, $sort: ContentSearchPPVSort!, $queryWord: String, $facetLimit: Int!, $excludeUndelivered: Boolean!) { legacySearchPPV(limit: $limit, offset: $offset, floor: $floor, sort: $sort, queryWord: $queryWord, facetLimit: $facetLimit, includeExplicit: true, excludeUndelivered: $excludeUndelivered) { result { contents { id title contentType } } } }";
+
+const buildDetailUrl = (contentId: string, path: DmmVideoDetailPath = "/av/content/?id="): string =>
+  `${DMM_VIDEO_BASE}${path}${contentId}`;
 
 const normalizeToken = (value: string): string => value.toLowerCase().replace(/[^a-z0-9]/gu, "");
 
+const appendUnique = (values: string[], value: string | undefined): void => {
+  if (!value || values.includes(value)) {
+    return;
+  }
+
+  values.push(value);
+};
+
+const buildSearchTerms = (number: string, candidateIds: string[]): string[] => {
+  const normalized = number.trim().toLowerCase();
+  const terms: string[] = [];
+  appendUnique(terms, normalized);
+  appendUnique(terms, normalized.replace(/\s+/gu, ""));
+  appendUnique(terms, normalized.replace(/[^a-z0-9]/gu, ""));
+
+  const matched = normalized.match(/(\d*[a-z]+)-?(\d+)/u);
+  if (matched) {
+    const prefix = matched[1] ?? "";
+    const digits = matched[2];
+    appendUnique(terms, `${prefix}-${digits}`);
+    appendUnique(terms, `${prefix}${digits}`);
+    appendUnique(terms, `${prefix}${digits.padStart(5, "0")}`);
+  }
+
+  for (const candidateId of candidateIds) {
+    appendUnique(terms, candidateId);
+    appendUnique(terms, candidateId.replace(/^1(?=[a-z])/u, ""));
+  }
+
+  return terms.filter((term) => term.length > 0);
+};
+
 const isVideoDetailUrl = (url: string): boolean => {
-  return url.includes("video.dmm.co.jp/av/content/?id=");
+  return DMM_VIDEO_DETAIL_PATHS.some((path) => url.includes(`video.dmm.co.jp${path}`));
+};
+
+const getVideoDetailContentId = (url: string): string | null => {
+  for (const path of DMM_VIDEO_DETAIL_PATHS) {
+    const marker = `${DMM_VIDEO_BASE}${path}`;
+    if (url.startsWith(marker)) {
+      return url.slice(marker.length).trim() || null;
+    }
+  }
+
+  return null;
+};
+
+const getAlternativeDetailUrls = (url: string): string[] => {
+  const contentId = getVideoDetailContentId(url);
+  if (!contentId) {
+    return [];
+  }
+
+  return DMM_VIDEO_DETAIL_PATHS.map((path) => buildDetailUrl(contentId, path)).filter((candidate) => candidate !== url);
 };
 
 const hasLoginWallTitle = (title: string | undefined): boolean => {
@@ -84,8 +181,74 @@ const buildDmmVideoPayload = (id: string): DmmVideoPayload => {
     query: CONTENT_PAGE_DATA_QUERY,
     variables: {
       id,
+      shouldFetchRelatedTags: true,
     },
   };
+};
+
+const buildDmmVideoSearchPayload = (floor: "AV" | "ANIME", queryWord: string): DmmVideoSearchPayload => {
+  return {
+    operationName: floor === "ANIME" ? "AnimeSearch" : "AvSearch",
+    query: floor === "ANIME" ? ANIME_SEARCH_QUERY : AV_SEARCH_QUERY,
+    variables: {
+      limit: 5,
+      offset: 0,
+      floor,
+      sort: "SALES_RANK_SCORE",
+      queryWord,
+      facetLimit: 1,
+      excludeUndelivered: false,
+    },
+  };
+};
+
+const pickSearchResultContentId = (context: DmmTvContext, payload: unknown): string | null => {
+  const contents = ((payload as DmmVideoSearchResponse)?.legacySearchPPV?.result?.contents ?? []).filter(
+    (item): item is { id: string; title?: string } => Boolean(item?.id),
+  );
+  if (contents.length === 0) {
+    return null;
+  }
+
+  const needles = Array.from(
+    new Set(
+      [context.number, ...context.searchTerms, ...context.candidateIds]
+        .map((value) => normalizeToken(value))
+        .filter((value) => value.length > 0),
+    ),
+  );
+
+  const scored = contents
+    .map((item) => {
+      const normalizedId = normalizeToken(item.id);
+      const normalizedTitle = normalizeToken(item.title ?? "");
+      let score = 0;
+
+      for (const needle of needles) {
+        if (normalizedId === needle) {
+          score = Math.max(score, 300);
+        } else if (normalizedTitle === needle) {
+          score = Math.max(score, 280);
+        } else if (normalizedId.includes(needle)) {
+          score = Math.max(score, 220);
+        } else if (normalizedTitle.includes(needle)) {
+          score = Math.max(score, 180);
+        }
+      }
+
+      return {
+        id: item.id,
+        score,
+      };
+    })
+    .sort((left, right) => right.score - left.score);
+
+  const best = scored[0];
+  if (best && best.score > 0) {
+    return best.id;
+  }
+
+  return contents.length === 1 ? contents[0]?.id ?? null : null;
 };
 
 const parseDmmVideoData = (payload: unknown, fallbackNumber: string): Partial<CrawlerData> | null => {
@@ -94,6 +257,19 @@ const parseDmmVideoData = (payload: unknown, fallbackNumber: string): Partial<Cr
   if (!content?.title) {
     return null;
   }
+
+  const relatedTags = uniqueStrings(
+    (content.relatedTags ?? []).flatMap((item) => {
+      if ("tags" in item && Array.isArray(item.tags)) {
+        return item.tags.map((tag) => tag.name);
+      }
+
+      return "name" in item ? [item.name] : [];
+    }),
+  );
+  const genres = uniqueStrings([...(content.genres ?? []).map((item) => item.name), ...relatedTags]).filter(
+    (value): value is string => Boolean(value),
+  );
 
   const number = content.makerContentId?.trim() || fallbackNumber;
   const trailer =
@@ -104,7 +280,7 @@ const parseDmmVideoData = (payload: unknown, fallbackNumber: string): Partial<Cr
     number,
     durationSeconds: typeof content.duration === "number" && content.duration > 0 ? content.duration : undefined,
     actors: (content.actresses ?? []).map((item) => item.name).filter((value): value is string => Boolean(value)),
-    genres: (content.genres ?? []).map((item) => item.name).filter((value): value is string => Boolean(value)),
+    genres,
     studio: content.maker?.name,
     director: (content.directors ?? []).map((item) => item.name).find((value): value is string => Boolean(value)),
     publisher: content.label?.name ?? content.maker?.name,
@@ -133,11 +309,25 @@ export class DmmTvCrawler extends BaseDmmCrawler {
   protected override newContext(input: CrawlerInput): DmmTvContext {
     const context = super.newContext(input) as DmmTvContext;
     context.candidateIds = normalizeContentIds(input.number);
+    context.searchTerms = buildSearchTerms(input.number, context.candidateIds);
     return context;
   }
 
   protected override async fetch(url: string, context: DmmTvContext): Promise<string> {
-    return this.gateway.fetchHtml(url, this.createFetchOptions(context));
+    try {
+      return await this.gateway.fetchHtml(url, this.createFetchOptions(context));
+    } catch (error) {
+      for (const fallbackUrl of getAlternativeDetailUrls(url)) {
+        try {
+          return await this.gateway.fetchHtml(fallbackUrl, this.createFetchOptions(context));
+        } catch (fallbackError) {
+          const message = toErrorMessage(fallbackError);
+          this.logger.debug(`DMM TV detail fallback miss for ${fallbackUrl}: ${message}`);
+        }
+      }
+
+      throw error;
+    }
   }
 
   protected async generateSearchUrl(context: DmmTvContext): Promise<string | null> {
@@ -160,7 +350,7 @@ export class DmmTvCrawler extends BaseDmmCrawler {
 
     const links = new Set<string>();
 
-    $("a[href*='/av/content/?id='], a[href*='video.dmm.co.jp/av/content/?id=']")
+    $("a[href*='/av/content/?id='], a[href*='video.dmm.co.jp/av/content/?id='], a[href*='/anime/content/?id='], a[href*='video.dmm.co.jp/anime/content/?id=']")
       .toArray()
       .map((element) => $(element).attr("href"))
       .filter((href): href is string => Boolean(href))
@@ -172,10 +362,15 @@ export class DmmTvCrawler extends BaseDmmCrawler {
       });
 
     const html = $.html();
-    for (const match of html.matchAll(/\/av\/content\/\?id=([a-z0-9]+)/giu)) {
+    for (const match of html.matchAll(/\/(?:av|anime)\/content\/\?id=([a-z0-9_]+)/giu)) {
       const id = match[1];
       if (id) {
-        links.add(buildDetailUrl(id));
+        const matchedUrl = match[0];
+        if (matchedUrl.includes("/anime/")) {
+          links.add(buildDetailUrl(id, "/anime/content/?id="));
+        } else {
+          links.add(buildDetailUrl(id));
+        }
       }
     }
 
@@ -237,6 +432,103 @@ export class DmmTvCrawler extends BaseDmmCrawler {
 
     const parsed = parseDigitalDetail($);
     if (!parsed?.title || hasLoginWallTitle(parsed.title)) {
+      const searchedDetailUrl = await this.tryResolveDetailUrlViaSearch(context, _detailUrl);
+      if (searchedDetailUrl && searchedDetailUrl !== _detailUrl) {
+        try {
+          const searchedContentId = getVideoDetailContentId(searchedDetailUrl);
+          if (searchedContentId) {
+            const searchedGraphQlData = await this.gateway.fetchGraphQL<unknown>(
+              DMM_VIDEO_GRAPHQL_ENDPOINT,
+              buildDmmVideoPayload(searchedContentId),
+              this.createGraphQlFetchOptions(context),
+            );
+            const searchedVideoData = parseDmmVideoData(searchedGraphQlData, context.number);
+            if (searchedVideoData?.title && !hasLoginWallTitle(searchedVideoData.title)) {
+              return {
+                title: searchedVideoData.title,
+                number: searchedVideoData.number ?? context.number,
+                durationSeconds: searchedVideoData.durationSeconds,
+                actors: searchedVideoData.actors ?? [],
+                genres: searchedVideoData.genres ?? [],
+                studio: searchedVideoData.studio,
+                director: searchedVideoData.director,
+                publisher: searchedVideoData.publisher ?? searchedVideoData.studio,
+                series: searchedVideoData.series,
+                plot: searchedVideoData.plot,
+                release_date: searchedVideoData.release_date,
+                rating: searchedVideoData.rating,
+                thumb_url: searchedVideoData.thumb_url,
+                poster_url: searchedVideoData.poster_url,
+                fanart_url: searchedVideoData.fanart_url,
+                scene_images: searchedVideoData.scene_images ?? [],
+                trailer_url: searchedVideoData.trailer_url,
+                website: Website.DMM_TV,
+              };
+            }
+          }
+
+          const searchedHtml = await this.gateway.fetchHtml(searchedDetailUrl, this.createFetchOptions(context));
+          const searchedData = parseDigitalDetail(load(searchedHtml));
+          if (searchedData?.title && !hasLoginWallTitle(searchedData.title)) {
+            return {
+              title: searchedData.title,
+              number: context.number,
+              durationSeconds: searchedData.durationSeconds,
+              actors: searchedData.actors ?? [],
+              genres: searchedData.genres ?? [],
+              studio: searchedData.studio,
+              director: searchedData.director,
+              publisher: searchedData.publisher ?? searchedData.studio,
+              series: searchedData.series,
+              plot: searchedData.plot,
+              release_date: searchedData.release_date,
+              rating: searchedData.rating,
+              thumb_url: searchedData.thumb_url,
+              poster_url: searchedData.poster_url,
+              fanart_url: searchedData.fanart_url,
+              scene_images: searchedData.scene_images ?? [],
+              trailer_url: searchedData.trailer_url,
+              website: Website.DMM_TV,
+            };
+          }
+        } catch (error) {
+          const message = toErrorMessage(error);
+          this.logger.debug(`DMM TV searched detail miss for ${searchedDetailUrl}: ${message}`);
+        }
+      }
+
+      for (const fallbackUrl of getAlternativeDetailUrls(_detailUrl)) {
+        try {
+          const fallbackHtml = await this.gateway.fetchHtml(fallbackUrl, this.createFetchOptions(context));
+          const fallbackParsed = parseDigitalDetail(load(fallbackHtml));
+          if (fallbackParsed?.title && !hasLoginWallTitle(fallbackParsed.title)) {
+            return {
+              title: fallbackParsed.title,
+              number: context.number,
+              durationSeconds: fallbackParsed.durationSeconds,
+              actors: fallbackParsed.actors ?? [],
+              genres: fallbackParsed.genres ?? [],
+              studio: fallbackParsed.studio,
+              director: fallbackParsed.director,
+              publisher: fallbackParsed.publisher ?? fallbackParsed.studio,
+              series: fallbackParsed.series,
+              plot: fallbackParsed.plot,
+              release_date: fallbackParsed.release_date,
+              rating: fallbackParsed.rating,
+              thumb_url: fallbackParsed.thumb_url,
+              poster_url: fallbackParsed.poster_url,
+              fanart_url: fallbackParsed.fanart_url,
+              scene_images: fallbackParsed.scene_images ?? [],
+              trailer_url: fallbackParsed.trailer_url,
+              website: Website.DMM_TV,
+            };
+          }
+        } catch (error) {
+          const message = toErrorMessage(error);
+          this.logger.debug(`DMM TV detail parse fallback miss for ${fallbackUrl}: ${message}`);
+        }
+      }
+
       return null;
     }
 
@@ -262,10 +554,10 @@ export class DmmTvCrawler extends BaseDmmCrawler {
     };
   }
 
-  private async tryGraphQL(context: DmmTvContext): Promise<Partial<CrawlerData> | null> {
+  private createGraphQlFetchOptions(context: DmmTvContext): FetchOptions {
     const baseOptions = this.createFetchOptions(context);
     const graphQlTimeout = Math.min(baseOptions.timeout ?? 20_000, 2_500);
-    const options: FetchOptions = {
+    return {
       ...baseOptions,
       timeout: graphQlTimeout,
       headers: {
@@ -276,6 +568,10 @@ export class DmmTvCrawler extends BaseDmmCrawler {
         accept: "application/graphql-response+json, application/graphql+json, application/json",
       },
     };
+  }
+
+  private async tryGraphQL(context: DmmTvContext): Promise<Partial<CrawlerData> | null> {
+    const options = this.createGraphQlFetchOptions(context);
     const candidateIds = Array.from(
       new Set(context.candidateIds.length > 0 ? context.candidateIds : normalizeContentIds(context.number)),
     );
@@ -294,6 +590,40 @@ export class DmmTvCrawler extends BaseDmmCrawler {
       } catch (error) {
         const message = toErrorMessage(error);
         this.logger.debug(`DMM VIDEO GraphQL miss for ${contentId}: ${message}`);
+      }
+    }
+
+    return null;
+  }
+
+  private async tryResolveDetailUrlViaSearch(context: DmmTvContext, currentDetailUrl: string): Promise<string | null> {
+    const options = this.createGraphQlFetchOptions(context);
+    const strategies: Array<{ floor: "AV" | "ANIME"; path: DmmVideoDetailPath }> = [
+      { floor: "AV", path: "/av/content/?id=" },
+      { floor: "ANIME", path: "/anime/content/?id=" },
+    ];
+
+    for (const strategy of strategies) {
+      for (const term of context.searchTerms) {
+        try {
+          const response = await this.gateway.fetchGraphQL<unknown>(
+            DMM_VIDEO_GRAPHQL_ENDPOINT,
+            buildDmmVideoSearchPayload(strategy.floor, term),
+            options,
+          );
+          const contentId = pickSearchResultContentId(context, response);
+          if (!contentId) {
+            continue;
+          }
+
+          const detailUrl = buildDetailUrl(contentId, strategy.path);
+          if (detailUrl !== currentDetailUrl) {
+            return detailUrl;
+          }
+        } catch (error) {
+          const message = toErrorMessage(error);
+          this.logger.debug(`DMM VIDEO search miss for ${strategy.floor}/${term}: ${message}`);
+        }
       }
     }
 

--- a/src/main/services/crawler/sites/dmm/index.ts
+++ b/src/main/services/crawler/sites/dmm/index.ts
@@ -6,6 +6,7 @@ import { type CheerioAPI, load } from "cheerio";
 
 import type { Context, CrawlerInput } from "../../base/types";
 import type { CrawlerRegistration } from "../../registration";
+import { toAbsoluteUrl } from "../helpers";
 
 import { BaseDmmCrawler } from "./BaseDmmCrawler";
 import { classifyDmmDetailFailure } from "./failureClassifier";
@@ -14,6 +15,7 @@ import { DmmCategory, parseCategory, parseDigitalDetail, parseMonoLikeDetail } f
 interface DmmContext extends Context {
   number00?: string;
   numberNo00?: string;
+  searchKeywords: string[];
 }
 
 const DMM_SEARCH_BASE = "https://www.dmm.co.jp/search/=/searchstr=";
@@ -23,7 +25,45 @@ const unescapeDetailUrl = (value: string): string => {
   return value.replaceAll("\\/", "/").replaceAll("\\u0026", "&");
 };
 
-const collectDetailUrls = (context: DmmContext, $: CheerioAPI): string[] => {
+const pushUnique = (values: string[], value: string | undefined): void => {
+  if (!value || values.includes(value)) {
+    return;
+  }
+
+  values.push(value);
+};
+
+const buildSearchKeywords = (number: string, number00?: string, numberNo00?: string): string[] => {
+  const normalized = number.trim().toLowerCase();
+  const keywords: string[] = [];
+  pushUnique(keywords, number00);
+  pushUnique(keywords, numberNo00);
+  pushUnique(keywords, normalized);
+  pushUnique(keywords, normalized.replace(/\s+/gu, ""));
+
+  const matched = normalized.match(/(\d*[a-z]+)-?(\d+)/u);
+  if (matched) {
+    const prefix = matched[1] ?? "";
+    const digits = matched[2];
+    pushUnique(keywords, `${prefix}-${digits}`);
+    pushUnique(keywords, `${prefix}${digits}`);
+    pushUnique(keywords, `${prefix}${digits.padStart(5, "0")}`);
+  }
+
+  return keywords.filter((keyword) => keyword.length > 0);
+};
+
+const buildDetailUrlNeedles = (context: DmmContext): string[] => {
+  return Array.from(
+    new Set(
+      context.searchKeywords
+        .map((keyword) => keyword.toLowerCase().replace(/[^a-z0-9]/gu, ""))
+        .filter((keyword) => keyword.length > 0),
+    ),
+  );
+};
+
+const collectDetailUrls = (context: DmmContext, $: CheerioAPI, searchUrl: string): string[] => {
   const htmlText = $.html();
   const escapedMatches = htmlText.matchAll(/detailUrl\\":\\"(.*?)\\"/giu);
   const plainMatches = htmlText.matchAll(/"detailUrl"\s*:\s*"(.*?)"/giu);
@@ -37,7 +77,7 @@ const collectDetailUrls = (context: DmmContext, $: CheerioAPI): string[] => {
     if (parsed.trim().length === 0) {
       return;
     }
-    urls.push(parsed);
+    pushUnique(urls, parsed);
   };
 
   for (const match of escapedMatches) {
@@ -48,23 +88,33 @@ const collectDetailUrls = (context: DmmContext, $: CheerioAPI): string[] => {
     pushUrl(match[1]);
   }
 
+  $("a[href]")
+    .toArray()
+    .map((element) => $(element).attr("href"))
+    .filter(
+      (href): href is string =>
+        Boolean(href) &&
+        (/\/(?:digital|mono|monthly|rental)\//u.test(href) ||
+          href.includes("/detail/=/cid=") ||
+          href.includes("tv.dmm.") ||
+          href.includes("video.dmm.co.jp")),
+    )
+    .forEach((href) => {
+      pushUrl(toAbsoluteUrl(searchUrl, href));
+    });
+
   if (urls.length === 0) {
     return [];
   }
 
-  const numberParts = context.number.toLowerCase().match(/(\d*[a-z]+)?-?(\d+)/u);
-  if (!numberParts) {
+  const needles = buildDetailUrlNeedles(context);
+  if (needles.length === 0) {
     return Array.from(urls);
   }
 
-  const prefix = numberParts[1] ?? "";
-  const digits = numberParts[2];
-  const n1 = `${prefix}${digits.padStart(5, "0")}`;
-  const n2 = `${prefix}${digits}`;
-
   return urls.filter((value) => {
-    const lowered = value.toLowerCase();
-    return new RegExp(`[^a-z]${n1}[^0-9]`, "u").test(lowered) || new RegExp(`[^a-z]${n2}[^0-9]`, "u").test(lowered);
+    const lowered = value.toLowerCase().replace(/[^a-z0-9]/gu, "");
+    return needles.some((needle) => lowered.includes(needle));
   });
 };
 
@@ -82,6 +132,7 @@ export class DmmCrawler extends BaseDmmCrawler {
     const variants = normalizeDmmNumberVariants(input.number);
     context.number00 = variants.number00;
     context.numberNo00 = variants.numberNo00;
+    context.searchKeywords = buildSearchKeywords(input.number, variants.number00, variants.numberNo00);
     return context;
   }
 
@@ -99,7 +150,7 @@ export class DmmCrawler extends BaseDmmCrawler {
   }
 
   protected async parseSearchPage(context: DmmContext, $: CheerioAPI, searchUrl: string): Promise<string | null> {
-    const currentResult = this.resolveDetailUrlFromSearchHtml(context, $);
+    const currentResult = this.resolveDetailUrlFromSearchHtml(context, $, searchUrl);
     if (currentResult) {
       return currentResult;
     }
@@ -111,7 +162,7 @@ export class DmmCrawler extends BaseDmmCrawler {
 
       try {
         const html = await this.gateway.fetchHtml(candidateSearchUrl, this.createFetchOptions(context));
-        const candidateResult = this.resolveDetailUrlFromSearchHtml(context, load(html));
+        const candidateResult = this.resolveDetailUrlFromSearchHtml(context, load(html), candidateSearchUrl);
         if (candidateResult) {
           return candidateResult;
         }
@@ -175,10 +226,7 @@ export class DmmCrawler extends BaseDmmCrawler {
   }
 
   private buildSearchUrls(context: DmmContext): string[] {
-    const variants = [context.number00, context.numberNo00].filter((value): value is string => Boolean(value));
-    const uniqueKeywords = Array.from(new Set(variants));
-
-    return uniqueKeywords.flatMap((keyword) => {
+    return context.searchKeywords.flatMap((keyword) => {
       const encodedKeyword = encodeURIComponent(keyword).replace(/%2D/giu, "-");
       return [
         `${DMM_SEARCH_BASE}${encodedKeyword}/sort=ranking/`,
@@ -187,8 +235,8 @@ export class DmmCrawler extends BaseDmmCrawler {
     });
   }
 
-  private resolveDetailUrlFromSearchHtml(context: DmmContext, $: CheerioAPI): string | null {
-    const detailUrls = collectDetailUrls(context, $);
+  private resolveDetailUrlFromSearchHtml(context: DmmContext, $: CheerioAPI, searchUrl: string): string | null {
+    const detailUrls = collectDetailUrls(context, $, searchUrl);
     return detailUrls[0] ?? null;
   }
 }

--- a/src/main/services/crawler/sites/dmm/parsers.ts
+++ b/src/main/services/crawler/sites/dmm/parsers.ts
@@ -17,6 +17,33 @@ export enum DmmCategory {
 type CheerioInput = Parameters<CheerioAPI>[0];
 const DMM_SCENE_IMAGE_PATTERN = /jp-\d+\.(?:jpe?g|png|webp)$/iu;
 const DMM_PRIMARY_IMAGE_PATTERN = /p[sl]\.(?:jpe?g|png|webp)$/iu;
+const DMM_NOISE_GENRES = new Set(["サンプル動画"]);
+
+const extractRelatedTags = ($: CheerioAPI): string[] => {
+  const texts = [
+    ...$("td:contains('関連タグ') + td a")
+      .toArray()
+      .map((element: CheerioInput) => $(element).text()),
+    ...$("th:contains('関連タグ') + td a")
+      .toArray()
+      .map((element: CheerioInput) => $(element).text()),
+  ];
+
+  return uniqueStrings(
+    texts.flatMap((text) => {
+      const normalized = text.replace(/\u3000/gu, " ").trim();
+      if (!normalized) {
+        return [];
+      }
+
+      const rawParts = normalized.includes("#") ? normalized.split(/\s+/u) : [normalized];
+      return rawParts.map((part) => part.replace(/^#+/u, "").trim()).filter((part) => part.length > 0);
+    }),
+  );
+};
+
+const normalizeDmmGenres = (values: Array<string | undefined>): string[] =>
+  uniqueStrings(values).filter((value) => !DMM_NOISE_GENRES.has(value));
 
 const normalizeDmmSceneImageUrl = (value: string | undefined): string | undefined => {
   if (!value || DMM_PRIMARY_IMAGE_PATTERN.test(value)) {
@@ -99,9 +126,10 @@ export const parseMonoLikeDetail = ($: CheerioAPI): Partial<CrawlerData> | null 
     ...extractList($, "th:contains('出演者') + td a"),
   ]);
 
-  const genres = uniqueStrings([
+  const genres = normalizeDmmGenres([
     ...extractList($, "td:contains('ジャンル') + td a"),
     ...extractList($, "th:contains('ジャンル') + td a"),
+    ...extractRelatedTags($),
   ]);
 
   const thumb =
@@ -154,7 +182,7 @@ export const parseDigitalDetail = ($: CheerioAPI): Partial<CrawlerData> | null =
 
   const images = jsonLd?.image ?? [];
   const actorsFromJson = uniqueStrings((jsonLd?.subjectOf?.actor ?? []).map((actor) => actor.name));
-  const genresFromJson = uniqueStrings(jsonLd?.subjectOf?.genre ?? []);
+  const genresFromJson = normalizeDmmGenres(jsonLd?.subjectOf?.genre ?? []);
   const releaseFromJson = parseDate(jsonLd?.subjectOf?.uploadDate) ?? undefined;
   const trailerFromJson = jsonLd?.subjectOf?.contentUrl;
   const ratingFromJson = jsonLd?.aggregateRating?.ratingValue;
@@ -172,7 +200,7 @@ export const parseDigitalDetail = ($: CheerioAPI): Partial<CrawlerData> | null =
     title: jsonLd?.name ?? base?.title,
     plot: jsonLd?.description ?? base?.plot,
     actors: actorsFromJson.length > 0 ? actorsFromJson : base?.actors,
-    genres: genresFromJson.length > 0 ? genresFromJson : base?.genres,
+    genres: normalizeDmmGenres([...(base?.genres ?? []), ...genresFromJson]),
     studio: jsonLd?.brand?.name ?? base?.studio,
     release_date: releaseFromJson ?? base?.release_date,
     rating: Number.isFinite(ratingFromJson) ? ratingFromJson : base?.rating,

--- a/src/main/services/scraper/NfoGenerator.ts
+++ b/src/main/services/scraper/NfoGenerator.ts
@@ -178,7 +178,8 @@ export class NfoGenerator {
     const localState = options?.localState;
     const durationSeconds = videoMeta?.durationSeconds ?? data.durationSeconds;
     const runtimeMinutes = durationSeconds ? Math.round(durationSeconds / 60) : undefined;
-    const tags = buildMovieTags(data, fileInfo, localState);
+    const genres = Array.from(new Set(buildStringNodes(toArray(data.genres))));
+    const tags = Array.from(new Set([...genres, ...buildMovieTags(data, fileInfo, localState)]));
     const videoNode = buildVideoNode(videoMeta);
 
     const movie: Record<string, unknown> = {};
@@ -215,7 +216,7 @@ export class NfoGenerator {
       "@_default": "true",
       "#text": data.number,
     };
-    movie.genre = Array.from(new Set(buildStringNodes(toArray(data.genres))));
+    movie.genre = genres;
     movie.tag = tags.length > 0 ? tags : undefined;
     movie.actor = buildActorNodes(toArray(data.actors), data.actor_profiles);
 

--- a/src/main/services/scraper/NfoGenerator.ts
+++ b/src/main/services/scraper/NfoGenerator.ts
@@ -166,8 +166,9 @@ export interface NfoOptions {
 export class NfoGenerator {
   buildXml(data: CrawlerData, options?: NfoOptions): string {
     const rawTitle = data.title_zh?.trim() || data.title;
+    const originaltitle = data.title.trim();
     const titleTemplate = options?.nfoTitleTemplate?.trim() || "{title}";
-    const title = renderPathTemplate(titleTemplate, { title: rawTitle, number: data.number });
+    const title = renderPathTemplate(titleTemplate, { title: rawTitle, originaltitle, number: data.number });
     const plot = data.plot_zh?.trim() || data.plot?.trim();
     const outline = plot ? truncateText(plot, OUTLINE_MAX_CHARS) : undefined;
     const assets = options?.assets;
@@ -188,7 +189,7 @@ export class NfoGenerator {
     }
 
     movie.title = title;
-    movie.originaltitle = data.title;
+    movie.originaltitle = originaltitle;
     movie.plot = plot && plot.length > 0 ? plot : undefined;
     movie.outline = outline;
     movie.premiered = data.release_date;

--- a/src/main/services/scraper/aggregation/FieldAggregator.ts
+++ b/src/main/services/scraper/aggregation/FieldAggregator.ts
@@ -41,6 +41,21 @@ const EMPTY_IMAGE_ALTERNATIVES: ImageAlternatives = {
   scene_image_sources: [],
 };
 
+const COHERENT_METADATA_FIELDS = new Set<keyof CrawlerData>([
+  "number",
+  "genres",
+  "content_type",
+  "studio",
+  "director",
+  "publisher",
+  "series",
+  "release_date",
+  "durationSeconds",
+  "rating",
+  "trailer_url",
+  "website",
+]);
+
 type PrimaryImageAlternativeField = "thumb_url" | "poster_url";
 
 function isPrimaryImageField(field: keyof CrawlerData): field is PrimaryImageAlternativeField {
@@ -75,8 +90,19 @@ export class FieldAggregator {
 
     // Use first entry as fallback for required fields
     const firstEntry = entries[0];
+    const preferredMetadataSource = this.resolvePreferredMetadataSource(entries);
 
     const resolve = <K extends keyof CrawlerData>(field: K): CrawlerData[K] => {
+      if (preferredMetadataSource && field !== "title" && COHERENT_METADATA_FIELDS.has(field)) {
+        const preferredResult = this.resolveFromPreferredSource(field, preferredMetadataSource);
+        if (preferredResult) {
+          if (preferredResult.value !== undefined && preferredResult.value !== null) {
+            sources[field] = preferredResult.source;
+          }
+          return preferredResult.value as CrawlerData[K];
+        }
+      }
+
       const strategy = FIELD_STRATEGIES[field] ?? "first_non_null";
       const priority = (this.priorities[field] ?? []) as Website[];
       const ordered = this.orderByPriority(entries, priority);
@@ -120,6 +146,50 @@ export class FieldAggregator {
     };
 
     return { data, sources, imageAlternatives };
+  }
+
+  private resolvePreferredMetadataSource(entries: SourceEntry[]): SourceEntry | undefined {
+    const strategy = FIELD_STRATEGIES.title ?? "first_non_null";
+    const priority = (this.priorities.title ?? []) as Website[];
+    const ordered = this.orderByPriority(entries, priority);
+    const resolved = this.applyStrategy("title", strategy, ordered);
+    return entries.find((entry) => entry.site === resolved.source);
+  }
+
+  private resolveFromPreferredSource(field: keyof CrawlerData, entry: SourceEntry): ResolvedField | null {
+    const value = entry.data[field];
+
+    if (field === "actors" || field === "genres") {
+      if (!Array.isArray(value) || value.length === 0) {
+        return null;
+      }
+
+      return {
+        value:
+          field === "actors"
+            ? value.slice(0, this.behavior.maxActors)
+            : value.slice(0, this.behavior.maxGenres),
+        source: entry.site,
+      };
+    }
+
+    if (typeof value === "string") {
+      if (value.length === 0 || looksLikeCode(value)) {
+        return null;
+      }
+
+      return { value, source: entry.site };
+    }
+
+    if (typeof value === "number") {
+      return Number.isFinite(value) ? { value, source: entry.site } : null;
+    }
+
+    if (value === undefined || value === null) {
+      return null;
+    }
+
+    return { value, source: entry.site };
   }
 
   private orderByPriority(entries: SourceEntry[], priority: Website[]): SourceEntry[] {

--- a/src/main/services/scraper/organize/NamingEngine.ts
+++ b/src/main/services/scraper/organize/NamingEngine.ts
@@ -178,12 +178,14 @@ const NAMING_PREVIEW_SAMPLES: Array<{
 export class NamingEngine {
   buildLayout(fileInfo: FileInfo, data: CrawlerData, config: Configuration, localState?: NfoLocalState): NamingLayout {
     const title = data.title_zh?.trim() || data.title;
+    const originaltitle = data.title.trim();
     const actorFolder = pickActorFolder(config, data.actors ?? [], data.studio);
     const styledNumber = buildNumberWithNamingMarkers(fileInfo, data, config, localState);
     const partSuffix = formatPartSuffix(fileInfo, config);
     const formattedReleaseDate = formatReleaseDateByRule(data.release_date, config.naming.releaseRule);
     const templateData = {
       title,
+      originaltitle,
       number: styledNumber,
       actor: actorFolder,
       date: formattedReleaseDate,

--- a/src/main/utils/nfo.ts
+++ b/src/main/utils/nfo.ts
@@ -1,6 +1,7 @@
 import { toArray } from "@main/utils/common";
 import { isManagedMovieTag, parseManagedMovieTags } from "@main/utils/movieMetadata";
 import { normalizeNfoLocalState, tagToUncensoredChoice } from "@main/utils/nfoLocalState";
+import { normalizeText } from "@main/utils/normalization";
 import { Website } from "@shared/enums";
 import type { ActorProfile, CrawlerData, NfoLocalState } from "@shared/types";
 import { XMLParser } from "fast-xml-parser";
@@ -170,6 +171,7 @@ export const parseNfoSnapshot = (xml: string): ParsedNfoSnapshot => {
     .filter((item): item is ActorProfile => item !== null);
 
   const genres = toStringArray(movieNode.genre);
+  const normalizedGenres = new Set(genres.map((genre) => normalizeText(genre)).filter((genre) => genre.length > 0));
   const tags = toStringArray(movieNode.tag);
   const managedMovieTags = parseManagedMovieTags(tags);
   let uncensoredChoice: NfoLocalState["uncensoredChoice"];
@@ -177,6 +179,10 @@ export const parseNfoSnapshot = (xml: string): ParsedNfoSnapshot => {
 
   for (const tag of tags) {
     if (isManagedMovieTag(tag)) {
+      continue;
+    }
+
+    if (normalizedGenres.has(normalizeText(tag))) {
       continue;
     }
 

--- a/src/main/utils/path.ts
+++ b/src/main/utils/path.ts
@@ -8,6 +8,7 @@ const OPTIONAL_GROUP = /\[([^[\]]*)\]/gu;
 
 export interface TemplateData {
   title?: string;
+  originaltitle?: string;
   number?: string;
   actor?: string;
   date?: string;

--- a/src/renderer/src/components/config-form/TabbedConfigForm.tsx
+++ b/src/renderer/src/components/config-form/TabbedConfigForm.tsx
@@ -100,7 +100,7 @@ const NFO_NAMING_OPTIONS: EnumOption[] = [
   { value: "filename", label: "仅 文件名.nfo" },
 ];
 
-export const NAMING_TEMPLATE_DESCRIPTION = "可用占位符：{actor} {number} {date} {title} {studio}";
+export const NAMING_TEMPLATE_DESCRIPTION = "可用占位符：{actor} {number} {date} {title} {originaltitle} {studio}";
 
 // ── Field registry for search/filter ──
 
@@ -524,7 +524,7 @@ export function NamingSection(_props: SectionRenderProps) {
       <TextField
         name="naming.nfoTitleTemplate"
         label="NFO 标题模板"
-        description="NFO 中 title 字段的格式。可用占位符：{number} {title}"
+        description="NFO 中 title 字段的格式。可用占位符：{number} {title} {originaltitle}"
       />
       <NamingPreview />
       <NumberField name="naming.actorNameMax" label="演员名最大数量" min={1} max={20} />

--- a/tests/unit/services/config/computed.test.ts
+++ b/tests/unit/services/config/computed.test.ts
@@ -166,6 +166,42 @@ describe("buildComputedConfiguration", () => {
     expect(result.success).toBe(true);
   });
 
+  it("treats title-based folder templates as dedicated movie directories", () => {
+    const result = configurationSchema.safeParse({
+      naming: {
+        folderTemplate: "/{title}",
+        assetNamingMode: "fixed",
+      },
+      behavior: {
+        successFileMove: true,
+      },
+      download: {
+        nfoNaming: "both",
+        downloadSceneImages: true,
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("treats original-title-based folder templates as dedicated movie directories", () => {
+    const result = configurationSchema.safeParse({
+      naming: {
+        folderTemplate: "/{originaltitle}",
+        assetNamingMode: "fixed",
+      },
+      behavior: {
+        successFileMove: true,
+      },
+      download: {
+        nfoNaming: "both",
+        downloadSceneImages: true,
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
   it("rejects optional groups that try to span multiple path segments", () => {
     const cases = [
       {

--- a/tests/unit/services/config/config_migrations.test.ts
+++ b/tests/unit/services/config/config_migrations.test.ts
@@ -364,6 +364,24 @@ describe("Configuration migrations", () => {
         {
           raw: buildV030Config({
             naming: {
+              folderTemplate: "/{title}",
+              fileTemplate: "{number}",
+            },
+          }),
+          expected: "/{title}",
+        },
+        {
+          raw: buildV030Config({
+            naming: {
+              folderTemplate: "/{originaltitle}",
+              fileTemplate: "{number}",
+            },
+          }),
+          expected: "/{originaltitle}",
+        },
+        {
+          raw: buildV030Config({
+            naming: {
               folderTemplate: "   ",
               fileTemplate: "{number}",
             },
@@ -381,6 +399,18 @@ describe("Configuration migrations", () => {
           expect(parsed.download.nfoNaming).toBe("filename");
           expect(parsed.download.downloadSceneImages).toBe(false);
           expect(parsed.download.keepSceneImages).toBe(false);
+        }
+
+        if (expected === "/{title}") {
+          expect(parsed.naming.assetNamingMode).toBe("fixed");
+          expect(parsed.download.nfoNaming).toBe("both");
+          expect(parsed.download.downloadSceneImages).toBe(true);
+        }
+
+        if (expected === "/{originaltitle}") {
+          expect(parsed.naming.assetNamingMode).toBe("fixed");
+          expect(parsed.download.nfoNaming).toBe("both");
+          expect(parsed.download.downloadSceneImages).toBe(true);
         }
       }
     });

--- a/tests/unit/services/crawler/dmm.test.ts
+++ b/tests/unit/services/crawler/dmm.test.ts
@@ -85,6 +85,66 @@ describe("DmmCrawler", () => {
         },
       },
       {
+        number: "ACPDP-1102",
+        searchUrl: "https://www.dmm.co.jp/search/=/searchstr=acpdp01102/sort=ranking/",
+        detailUrl: "https://www.dmm.co.jp/digital/videoa/-/detail/=/cid=acpdp01102/",
+        searchHtml: (detailUrl: string) => `
+          <html><body>
+            <script>
+              const item = {"detailUrl":"${detailUrl.replaceAll("/", "\\/")}"};
+            </script>
+          </body></html>
+        `,
+        detailHtml: `
+          <html><body>
+            <h1><span>Genre Merge Test</span></h1>
+            <table>
+              <tr><th>ジャンル</th><td>
+                <a>Tag 1</a><a>サンプル動画</a><a>Tag 2</a><a>Tag 3</a><a>Tag 4</a><a>Tag 5</a>
+                <a>Tag 6</a><a>Tag 7</a><a>Tag 8</a><a>Tag 9</a><a>Tag 10</a>
+              </td></tr>
+              <tr><th>関連タグ</th><td>
+                <ul>
+                  <li><a>#Tag11 #Tag12</a></li>
+                  <li><a>#Tag12 #Tag13</a></li>
+                </ul>
+              </td></tr>
+              <tr><th>メーカー</th><td><a>Studio Merge</a></td></tr>
+            </table>
+            <script type="application/ld+json">
+            {
+              "name": "Genre Merge Test",
+              "image": ["https://pics.dmm.co.jp/digital/video/acpdp01102/acpdp01102pl.jpg"],
+              "subjectOf": {
+                "genre": ["Tag 1", "Tag 2"]
+              }
+            }
+            </script>
+          </body></html>
+        `,
+        assert: (response: Awaited<ReturnType<DmmCrawler["crawl"]>>) => {
+          if (!response.result.success) {
+            throw new Error("expected success");
+          }
+
+          expect(response.result.data.genres).toEqual([
+            "Tag 1",
+            "Tag 2",
+            "Tag 3",
+            "Tag 4",
+            "Tag 5",
+            "Tag 6",
+            "Tag 7",
+            "Tag 8",
+            "Tag 9",
+            "Tag 10",
+            "Tag11",
+            "Tag12",
+            "Tag13",
+          ]);
+        },
+      },
+      {
         number: "SSIS-027",
         searchUrl: "https://www.dmm.co.jp/search/=/searchstr=ssis00027/sort=ranking/",
         detailUrl: "https://www.dmm.co.jp/digital/videoa/-/detail/=/cid=ssis00027/",
@@ -251,5 +311,50 @@ describe("DmmCrawler", () => {
     }
 
     expect(response.result.error).not.toContain("Missing fixture for https://api.tv.dmm.com/graphql");
+  });
+
+  it("falls back to additional search keywords and parses direct detail anchors", async () => {
+    const number = "KNBM-007";
+    const primarySearchUrl = "https://www.dmm.co.jp/search/=/searchstr=knbm00007/sort=ranking/";
+    const compactSearchUrl = "https://www.dmm.co.jp/search/=/searchstr=knbm007/sort=ranking/";
+    const hyphenatedSearchUrl = "https://www.dmm.co.jp/search/=/searchstr=knbm-007/sort=ranking/";
+    const detailUrl = "https://www.dmm.co.jp/digital/videoa/-/detail/=/cid=knbm007/";
+
+    const fixtures = new Map<string, unknown>([
+      [primarySearchUrl, "<html><body><div>no match</div></body></html>"],
+      [compactSearchUrl, "<html><body><div>still no match</div></body></html>"],
+      [
+        hyphenatedSearchUrl,
+        `<html><body><a href="${detailUrl}">KNBM-007 Detail</a></body></html>`,
+      ],
+      [
+        detailUrl,
+        `
+          <html><body>
+            <h1><span>KNBM Search Recovery</span></h1>
+            <table>
+              <tr><th>鍑烘紨鑰?/th><td><a>Actor Recovery</a></td></tr>
+              <tr><th>銈搞儯銉炽儷</th><td><a>Tag Recovery</a></td></tr>
+            </table>
+          </body></html>
+        `,
+      ],
+    ]);
+
+    const networkClient = new FixtureNetworkClient(fixtures);
+    const crawler = new DmmCrawler(withGateway(networkClient));
+
+    const response = await crawler.crawl({
+      number,
+      site: Website.DMM,
+    });
+
+    expect(response.result.success).toBe(true);
+    if (!response.result.success) {
+      throw new Error("expected success");
+    }
+
+    expect(response.result.data.title).toBe("KNBM Search Recovery");
+    expect(networkClient.requests.map((request) => request.url)).toContain(hyphenatedSearchUrl);
   });
 });

--- a/tests/unit/services/crawler/dmm_tv.test.ts
+++ b/tests/unit/services/crawler/dmm_tv.test.ts
@@ -1,8 +1,106 @@
 import { DmmTvCrawler } from "@main/services/crawler/sites/dmm/dmm_tv";
 import { Website } from "@shared/enums";
+import { NetworkClient } from "@main/services/network";
 import { describe, expect, it } from "vitest";
 
 import { FixtureNetworkClient, withGateway } from "./fixtures";
+
+class BodyAwareDmmTvNetworkClient extends NetworkClient {
+  readonly requests: Array<{ url: string; body?: unknown }> = [];
+
+  constructor(private readonly htmlFixtures: Map<string, string>) {
+    super({});
+  }
+
+  override async getText(url: string): Promise<string> {
+    this.requests.push({ url });
+    const fixture = this.htmlFixtures.get(url);
+    if (!fixture) {
+      throw new Error(`Missing fixture for ${url}`);
+    }
+
+    return fixture;
+  }
+
+  override async postJson<TResponse>(url: string, payload: unknown): Promise<TResponse> {
+    this.requests.push({ url, body: payload });
+    if (url !== "https://api.video.dmm.co.jp/graphql") {
+      throw new Error(`Missing fixture for ${url}`);
+    }
+
+    const operation = payload as {
+      operationName?: string;
+      variables?: Record<string, unknown>;
+    };
+    const operationName = operation.operationName;
+
+    if (operationName === "ContentPageData") {
+      const id = String(operation.variables?.id ?? "");
+      if (id === "realknbm007") {
+        return {
+          data: {
+            ppvContent: {
+              title: "Resolved GraphQL KNBM Title",
+              makerContentId: "KNBM-007",
+              description: "Recovered through search",
+              makerReleasedAt: "2025-05-18T00:00:00Z",
+              duration: 3600,
+              packageImage: {
+                largeUrl: "https://cdn.example.com/knbm-cover.jpg",
+                mediumUrl: "https://cdn.example.com/knbm-poster.jpg",
+              },
+              sampleImages: [{ largeImageUrl: "https://cdn.example.com/knbm-sample.jpg" }],
+              actresses: [{ name: "Actor KNBM" }],
+              genres: [{ name: "Tag KNBM" }],
+            },
+            reviewSummary: { average: 4.1 },
+          },
+        } as TResponse;
+      }
+
+      return { data: {} } as TResponse;
+    }
+
+    if (operationName === "AvSearch") {
+      const queryWord = String(operation.variables?.queryWord ?? "");
+      if (queryWord === "knbm-007") {
+        return {
+          data: {
+            legacySearchPPV: {
+              result: {
+                contents: [{ id: "realknbm007", title: "KNBM-007 Search Hit" }],
+              },
+            },
+          },
+        } as TResponse;
+      }
+
+      return {
+        data: {
+          legacySearchPPV: {
+            result: {
+              contents: [],
+            },
+          },
+        },
+      } as TResponse;
+    }
+
+    if (operationName === "AnimeSearch") {
+      return {
+        data: {
+          legacySearchPPV: {
+            result: {
+              contents: [],
+            },
+          },
+        },
+      } as TResponse;
+    }
+
+    throw new Error(`Unexpected payload for ${url}`);
+  }
+}
 
 describe("DmmTvCrawler", () => {
   it("resolves detail ids for prefixed and non-prefixed numbers", async () => {
@@ -52,6 +150,32 @@ describe("DmmTvCrawler", () => {
             (request) => request.url === "https://video.dmm.co.jp/av/content/?id=1stars00804",
           );
           expect(detailRequest?.headers.get("accept-language")).toBe("ja-JP,ja;q=0.9");
+        },
+      },
+      {
+        number: "ACPDP-1102",
+        detailUrl: "https://video.dmm.co.jp/anime/content/?id=1acpdp01102",
+        detailHtml: `
+          <html><body>
+            <h1 id="title"><span>DMM TV ACPDP</span></h1>
+            <table>
+              <tr><th>出演者</th><td><a>Actor ACPDP</a></td></tr>
+              <tr><th>ジャンル</th><td><a>Tag Anime</a><a>Tag Extra</a></td></tr>
+            </table>
+          </body></html>
+        `,
+        assert: (response: Awaited<ReturnType<DmmTvCrawler["crawl"]>>, networkClient: FixtureNetworkClient) => {
+          if (!response.result.success) {
+            throw new Error("expected success");
+          }
+          expect(response.result.data.title).toBe("DMM TV ACPDP");
+          expect(response.result.data.genres).toEqual(["Tag Anime", "Tag Extra"]);
+          expect(networkClient.requests.map((request) => request.url)).toContain(
+            "https://video.dmm.co.jp/av/content/?id=1acpdp01102",
+          );
+          expect(networkClient.requests.map((request) => request.url)).toContain(
+            "https://video.dmm.co.jp/anime/content/?id=1acpdp01102",
+          );
         },
       },
     ];
@@ -136,6 +260,7 @@ describe("DmmTvCrawler", () => {
               maker: { name: "Studio TV" },
               label: { name: "Publisher TV" },
               genres: [{ name: "Tag TV" }],
+              relatedTags: [{ name: "Related TV" }, { tags: [{ name: "Tag TV" }, { name: "Extra TV" }] }],
             },
             reviewSummary: { average: 3.8 },
           },
@@ -159,7 +284,42 @@ describe("DmmTvCrawler", () => {
     expect(response.result.data.number).toBe("STARS-804");
     expect(response.result.data.durationSeconds).toBe(5400);
     expect(response.result.data.actors).toEqual(["Actor TV"]);
+    expect(response.result.data.genres).toEqual(["Tag TV", "Related TV", "Extra TV"]);
     expect(response.result.data.thumb_url).toBe("https://cdn.example.com/cover.jpg");
     expect(response.result.data.trailer_url).toBe("https://video.example.com/stars804.mp4");
+  });
+
+  it("searches GraphQL for a real content id when guessed ids miss", async () => {
+    const guessedDetailUrl = "https://video.dmm.co.jp/av/content/?id=1knbm00007";
+    const networkClient = new BodyAwareDmmTvNetworkClient(
+      new Map<string, string>([[guessedDetailUrl, `<html><body><script>self.__next_f.push([1,"shell"])</script></body></html>`]]),
+    );
+    const crawler = new DmmTvCrawler(withGateway(networkClient));
+
+    const response = await crawler.crawl({
+      number: "KNBM-007",
+      site: Website.DMM_TV,
+    });
+
+    expect(response.result.success).toBe(true);
+    if (!response.result.success) {
+      throw new Error("expected success");
+    }
+
+    expect(response.result.data.title).toBe("Resolved GraphQL KNBM Title");
+    expect(response.result.data.number).toBe("KNBM-007");
+    expect(response.result.data.genres).toEqual(["Tag KNBM"]);
+    const payloads = networkClient.requests.filter((request) => request.url === "https://api.video.dmm.co.jp/graphql");
+    expect(payloads.some((request) => (request.body as { operationName?: string })?.operationName === "AvSearch")).toBe(
+      true,
+    );
+    expect(
+      payloads.some(
+        (request) =>
+          (request.body as { operationName?: string; variables?: Record<string, unknown> })?.operationName ===
+            "ContentPageData" &&
+          String((request.body as { variables?: Record<string, unknown> })?.variables?.id ?? "") === "realknbm007",
+      ),
+    ).toBe(true);
   });
 });

--- a/tests/unit/services/scraper/aggregation.test.ts
+++ b/tests/unit/services/scraper/aggregation.test.ts
@@ -161,6 +161,43 @@ describe("FieldAggregator", () => {
     expect(sources.scene_images).toBe(Website.DMM);
   });
 
+  it("keeps metadata coherent with the title-winning source when that source has values", () => {
+    const aggregator = new FieldAggregator({
+      title: [Website.DMM_TV, Website.JAV321],
+      genres: [Website.JAV321, Website.DMM_TV],
+      studio: [Website.JAV321, Website.DMM_TV],
+    });
+    const results = new Map<Website, CrawlerData>([
+      [
+        Website.DMM_TV,
+        makeCrawlerData({
+          title: "DMM TV Title",
+          genres: ["Tag TV 1", "Tag TV 2"],
+          studio: "Studio TV",
+          website: Website.DMM_TV,
+        }),
+      ],
+      [
+        Website.JAV321,
+        makeCrawlerData({
+          title: "JAV321 Title",
+          genres: ["Tag JAV321"],
+          studio: "Studio JAV321",
+          website: Website.JAV321,
+        }),
+      ],
+    ]);
+
+    const { data, sources } = aggregator.aggregate(results);
+
+    expect(data.title).toBe("DMM TV Title");
+    expect(data.genres).toEqual(["Tag TV 1", "Tag TV 2"]);
+    expect(data.studio).toBe("Studio TV");
+    expect(sources.title).toBe(Website.DMM_TV);
+    expect(sources.genres).toBe(Website.DMM_TV);
+    expect(sources.studio).toBe(Website.DMM_TV);
+  });
+
   it("respects maxActors limit", () => {
     const aggregator = new FieldAggregator({}, { maxActors: 2 });
     const results = new Map<Website, CrawlerData>([

--- a/tests/unit/services/scraper/file_organizer_settings.test.ts
+++ b/tests/unit/services/scraper/file_organizer_settings.test.ts
@@ -1208,4 +1208,30 @@ describe("FileOrganizer naming settings", () => {
       nfoPath: join(root, "output", "FC2-123456", "FC2-123456.nfo"),
     });
   });
+
+  it("supports originaltitle in folder and file templates without replacing title", () => {
+    const organizer = new FileOrganizer();
+    const plan = organizer.plan(
+      createFileInfo({
+        filePath: "/input/source.mp4",
+        fileName: "source",
+      }),
+      createCrawlerData({
+        number: "ABC-123",
+        title: "Original Title",
+        title_zh: "中文标题",
+        actors: ["Actor A"],
+      }),
+      createConfig({
+        naming: {
+          folderTemplate: "{actor}/{originaltitle}",
+          fileTemplate: "{number} {originaltitle}",
+          censoredStyle: "",
+        },
+      }),
+    );
+
+    expect(splitSegments(plan.outputDir).slice(-4)).toEqual(["media", "output", "Actor A", "Original Title"]);
+    expect(parse(plan.targetVideoPath).name).toBe("ABC-123 Original Title");
+  });
 });

--- a/tests/unit/services/scraper/nfo_generator_duration.test.ts
+++ b/tests/unit/services/scraper/nfo_generator_duration.test.ts
@@ -128,14 +128,14 @@ describe("NfoGenerator", () => {
     expect(xml).toContain("<thumb>https://img.example.com/actor-a.jpg</thumb>");
     expect(xml).toContain("<order>0</order>");
     expect(xml).toContain("<sortorder>0</sortorder>");
-    expect(xml).not.toContain("<tag>Drama</tag>");
+    expect(xml).toContain("<tag>Drama</tag>");
     expect(xml).toContain("<tag>mdcz:content_type:VR</tag>");
     expect(xml).not.toContain("<altname>");
     expect(xml).not.toContain("<biography>");
     expect(xml).not.toContain("<website>");
   });
 
-  it("omits tag nodes when there is no extra managed movie tag", () => {
+  it("mirrors genre nodes into tag nodes even when there is no extra managed movie tag", () => {
     const xml = new NfoGenerator().buildXml(
       createCrawlerData({
         genres: ["Drama"],
@@ -143,7 +143,7 @@ describe("NfoGenerator", () => {
     );
 
     expect(xml).toContain("<genre>Drama</genre>");
-    expect(xml).not.toContain("<tag>");
+    expect(xml).toContain("<tag>Drama</tag>");
   });
 
   it("injects classification tags when fileInfo is provided", () => {

--- a/tests/unit/services/scraper/nfo_generator_duration.test.ts
+++ b/tests/unit/services/scraper/nfo_generator_duration.test.ts
@@ -287,6 +287,21 @@ describe("NfoGenerator", () => {
     expect(xml).toContain('<uniqueid type="dmm" default="true">ABC-123</uniqueid>');
   });
 
+  it("supports originaltitle in the NFO title template", () => {
+    const xml = new NfoGenerator().buildXml(
+      createCrawlerData({
+        title: "Original Title",
+        title_zh: "中文标题",
+      }),
+      {
+        nfoTitleTemplate: "{number} {originaltitle}",
+      },
+    );
+
+    expect(xml).toContain("<title>ABC-123 Original Title</title>");
+    expect(xml).toContain("<originaltitle>Original Title</originaltitle>");
+  });
+
   it("uses thumb artwork as fallback fanart and persists sample image urls under mdcz", () => {
     const xml = new NfoGenerator().buildXml(
       createCrawlerData({

--- a/tests/unit/utils/nfo.test.ts
+++ b/tests/unit/utils/nfo.test.ts
@@ -221,4 +221,29 @@ describe("parseNfo", () => {
       tags: ["中文字幕", "自定义标签"],
     });
   });
+
+  it("does not restore mirrored genre tags as localState tags", () => {
+    const xml = new NfoGenerator().buildXml(
+      {
+        title: "Genre Mirror",
+        number: "ABC-654",
+        actors: [],
+        genres: ["Drama", "Mystery"],
+        scene_images: [],
+        website: Website.DMM,
+      },
+      {
+        localState: {
+          tags: ["自定义标签"],
+        },
+      },
+    );
+
+    const parsed = parseNfoSnapshot(xml);
+
+    expect(parsed.crawlerData.genres).toEqual(["Drama", "Mystery"]);
+    expect(parsed.localState).toEqual({
+      tags: ["自定义标签"],
+    });
+  });
 });


### PR DESCRIPTION
Summary（摘要）
为文件夹、文件和 NFO 标题模板新增 {originaltitle} 占位符支持
保持现有 {title} 的行为不变，避免触发共享目录限制
将 {originaltitle} 模板视为独立的影片目录，以避免触发共享目录限制
更新配置说明文本，并添加回归测试