### PR TITLE
fix(translate): make LLM request timeout configurable

### DIFF
--- a/packages/runtime/src/runtimeActions.test.ts
+++ b/packages/runtime/src/runtimeActions.test.ts
@@ -53,6 +53,7 @@ describe("settings parity runtime helpers", () => {
         baseUrl: "https://example.test/v1",
         model: "gpt-test",
         prompt: "简体中文:ある日の暮方の事である。",
+        timeout: 10_000,
       }),
     );
   });

--- a/packages/runtime/src/scrape/translate/engines/LlmApiClient.ts
+++ b/packages/runtime/src/scrape/translate/engines/LlmApiClient.ts
@@ -7,7 +7,7 @@ export interface LlmApiTransport {
   postJsonDetailed<TResponse>(
     url: string,
     payload: unknown,
-    init?: { headers?: LlmHeadersInit; signal?: AbortSignal },
+    init?: { headers?: LlmHeadersInit; signal?: AbortSignal; timeout?: number },
   ): Promise<RuntimeNetworkJsonResponse<TResponse>>;
 }
 
@@ -26,6 +26,7 @@ export interface LlmTextRequest {
   baseUrl: string;
   temperature: number;
   prompt: string;
+  timeout?: number;
 }
 
 interface ResponsesApiResponse {
@@ -87,16 +88,23 @@ class FetchLlmApiTransport implements LlmApiTransport {
   async postJsonDetailed<TResponse>(
     url: string,
     payload: unknown,
-    init: { headers?: LlmHeadersInit; signal?: AbortSignal } = {},
+    init: { headers?: LlmHeadersInit; signal?: AbortSignal; timeout?: number } = {},
   ): Promise<RuntimeNetworkJsonResponse<TResponse>> {
     const headers = new Headers(init.headers);
     headers.set("content-type", "application/json");
-    const response = await globalThis.fetch(url, {
-      body: JSON.stringify(payload),
-      headers,
-      method: "POST",
-      signal: init.signal,
-    });
+    const { signal, cleanup } = this.resolveSignal(init.signal, init.timeout);
+    let response: Response;
+
+    try {
+      response = await globalThis.fetch(url, {
+        body: JSON.stringify(payload),
+        headers,
+        method: "POST",
+        signal,
+      });
+    } finally {
+      cleanup();
+    }
 
     return {
       data: await this.parseJsonResponseBody<TResponse>(response),
@@ -120,6 +128,33 @@ class FetchLlmApiTransport implements LlmApiTransport {
       return text;
     }
   }
+
+  private resolveSignal(signal?: AbortSignal, timeout?: number): { signal?: AbortSignal; cleanup: () => void } {
+    if (!timeout || !Number.isFinite(timeout)) {
+      return { signal, cleanup: () => undefined };
+    }
+
+    const controller = new AbortController();
+    const timeoutMs = Math.max(1, Math.trunc(timeout));
+    const onAbort = () => controller.abort(signal?.reason);
+    const timeoutId = globalThis.setTimeout(() => {
+      controller.abort(new Error(`Request timeout (${timeoutMs} ms)`));
+    }, timeoutMs);
+
+    if (signal?.aborted) {
+      onAbort();
+    } else {
+      signal?.addEventListener("abort", onAbort, { once: true });
+    }
+
+    return {
+      signal: controller.signal,
+      cleanup: () => {
+        globalThis.clearTimeout(timeoutId);
+        signal?.removeEventListener("abort", onAbort);
+      },
+    };
+  }
 }
 
 export class LlmApiClient {
@@ -141,7 +176,7 @@ export class LlmApiClient {
         input: request.prompt,
         temperature: request.temperature,
       },
-      { headers, signal },
+      { headers, signal, timeout: request.timeout },
     );
 
     if (responsesResponse.ok) {
@@ -178,7 +213,7 @@ export class LlmApiClient {
           },
         ],
       },
-      { headers, signal },
+      { headers, signal, timeout: request.timeout },
     );
 
     if (!response.ok) {
@@ -199,7 +234,7 @@ export class LlmApiClient {
   private async postJsonDetailed<TResponse>(
     url: string,
     payload: unknown,
-    init?: { headers?: LlmHeadersInit; signal?: AbortSignal },
+    init?: { headers?: LlmHeadersInit; signal?: AbortSignal; timeout?: number },
   ): Promise<RuntimeNetworkJsonResponse<TResponse>> {
     try {
       return await this.transport.postJsonDetailed<TResponse>(url, payload, init);

--- a/packages/runtime/src/scrape/translate/engines/OpenAiTranslator.ts
+++ b/packages/runtime/src/scrape/translate/engines/OpenAiTranslator.ts
@@ -104,6 +104,7 @@ export class OpenAiTranslator {
             baseUrl: config.translate.llmBaseUrl,
             temperature,
             prompt,
+            timeout: this.getTimeoutMs(config),
           },
           signal,
         ),
@@ -118,6 +119,15 @@ export class OpenAiTranslator {
     }
 
     return Math.max(1, Math.trunc(configured));
+  }
+
+  private getTimeoutMs(config: Configuration): number {
+    const configured = Number(config.translate.llmTimeout);
+    if (!Number.isFinite(configured)) {
+      return 10_000;
+    }
+
+    return Math.max(1, Math.trunc(configured)) * 1000;
   }
 
   private getQueue(config: Configuration): PQueue {

--- a/packages/runtime/src/tools/batchNfoTranslator.ts
+++ b/packages/runtime/src/tools/batchNfoTranslator.ts
@@ -251,6 +251,7 @@ const translateChunk = async (
       baseUrl: config.translate.llmBaseUrl,
       temperature: 0,
       prompt: buildBatchPrompt(texts, target),
+      timeout: Math.max(1, Math.trunc(config.translate.llmTimeout)) * 1000,
     },
     undefined,
   );

--- a/packages/runtime/src/translate/llmTest.ts
+++ b/packages/runtime/src/translate/llmTest.ts
@@ -13,6 +13,7 @@ export interface TranslateTestLlmInput {
   llmBaseUrl?: string;
   llmPrompt?: string;
   llmTemperature?: number;
+  llmTimeout?: number;
 }
 
 export interface TranslateTestLlmResult {
@@ -35,6 +36,10 @@ export const testLlmConnectivity = async (
     typeof input?.llmTemperature === "number" && Number.isFinite(input.llmTemperature)
       ? input.llmTemperature
       : configuration.translate.llmTemperature;
+  const llmTimeout =
+    typeof input?.llmTimeout === "number" && Number.isFinite(input.llmTimeout)
+      ? input.llmTimeout
+      : configuration.translate.llmTimeout;
 
   if (!llmModelName.trim()) {
     return { success: false, message: "请先填写 LLM 模型名称" };
@@ -54,6 +59,7 @@ export const testLlmConnectivity = async (
       baseUrl: normalizedBaseUrl,
       temperature: Math.min(2, Math.max(0, llmTemperature)),
       prompt: llmPrompt.replaceAll("{lang}", "简体中文").replaceAll("{content}", "ある日の暮方の事である。"),
+      timeout: Math.max(1, Math.trunc(llmTimeout)) * 1000,
     });
     logger?.info(`Test LLM connectivity: Success, reply="${content}"`);
 

--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -81,6 +81,7 @@ const translateSchema = z.object({
   llmBaseUrl: z.url().or(z.literal("")).default(DEFAULT_LLM_BASE_URL),
   llmPrompt: z.string().default("自动识别原文语言，将以下内容翻译为{lang}。只输出最终翻译结果。\\n{content}"),
   llmTemperature: z.number().min(0).max(2).default(1.0),
+  llmTimeout: z.number().int().min(1).max(300).default(10),
   llmMaxRetries: z.number().int().min(1).max(20).default(3),
   llmMaxRequestsPerSecond: z.number().int().min(1).max(100).default(1),
   targetLanguage: translationTargetSchema,

--- a/packages/shared/ipcTypes.ts
+++ b/packages/shared/ipcTypes.ts
@@ -24,6 +24,7 @@ export type TranslateTestLlmInput = {
   llmBaseUrl?: string;
   llmPrompt?: string;
   llmTemperature?: number;
+  llmTimeout?: number;
 };
 
 export type ConnectionCheckStatus = "ok" | "error" | "skipped";

--- a/packages/shared/serverDtos.ts
+++ b/packages/shared/serverDtos.ts
@@ -860,6 +860,7 @@ export const translateTestLlmInputSchema = z.object({
   llmBaseUrl: z.string().optional(),
   llmPrompt: z.string().optional(),
   llmTemperature: z.number().optional(),
+  llmTimeout: z.number().optional(),
 });
 
 export type TranslateTestLlmInputDto = z.infer<typeof translateTestLlmInputSchema>;

--- a/packages/shared/settingsRegistry.ts
+++ b/packages/shared/settingsRegistry.ts
@@ -402,6 +402,7 @@ const RAW_FIELD_REGISTRY: Array<
   { key: "translate.llmBaseUrl", label: "LLM API 地址", anchor: "translate" },
   { key: "translate.llmPrompt", label: "LLM 翻译提示词", anchor: "translate" },
   { key: "translate.llmTemperature", label: "LLM 温度", anchor: "translate" },
+  { key: "translate.llmTimeout", label: "LLM 请求超时", anchor: "translate" },
   { key: "translate.llmMaxRetries", label: "LLM 最大重试次数", anchor: "translate" },
   { key: "translate.llmMaxRequestsPerSecond", label: "LLM 每秒最大请求数", anchor: "translate" },
   { key: "translate.targetLanguage", label: "目标语言", anchor: "translate" },

--- a/packages/views/src/settings/settingsContent.tsx
+++ b/packages/views/src/settings/settingsContent.tsx
@@ -783,6 +783,7 @@ export function TranslateSection() {
       llmBaseUrl: String(form.getValues("translate.llmBaseUrl") ?? ""),
       llmPrompt: String(form.getValues("translate.llmPrompt") ?? ""),
       llmTemperature: Number(form.getValues("translate.llmTemperature") ?? 0),
+      llmTimeout: Number(form.getValues("translate.llmTimeout") ?? 10),
     };
 
     setTesting(true);
@@ -845,6 +846,7 @@ export function TranslateSection() {
           />
           <PromptFieldWrapper name="translate.llmPrompt" label="LLM 翻译提示词" />
           <NumberField name="translate.llmTemperature" label="LLM 温度" min={0} max={2} step={0.1} />
+          <NumberField name="translate.llmTimeout" label="LLM 请求超时(秒)" min={1} max={300} />
           <NumberField name="translate.llmMaxRetries" label="LLM 最大重试次数" min={1} max={20} />
           <NumberField name="translate.llmMaxRequestsPerSecond" label="LLM 每秒最大请求数" min={1} max={100} />
         </>


### PR DESCRIPTION
Add translate.llmTimeout and pass it through LLM translation, connectivity tests, and batch NFO translation requests.

Fixes ShotHeadman/mdcz#70

给大模型翻译请求增加一个请求超时配置，避免默认的10秒超时翻译不了，解决 #70 