### PR TITLE
fix(tools): keep active tool when returning to tools route

### DIFF
--- a/packages/views/src/tools/ToolsRouteView.tsx
+++ b/packages/views/src/tools/ToolsRouteView.tsx
@@ -5,6 +5,16 @@ import { type ReactNode, useRef, useState } from "react";
 import { ToolCatalogView } from "./ToolCatalogView";
 import { ToolCardIcon } from "./ToolScaffold";
 
+const SELECTED_TOOL_STORAGE_KEY = "mdcz:selected-tool-id";
+const noopStorage = {
+  getItem: () => null,
+  setItem: () => undefined,
+  removeItem: () => undefined,
+};
+
+const getToolStorage = (): Pick<Storage, "getItem" | "setItem" | "removeItem"> =>
+  typeof sessionStorage !== "undefined" ? sessionStorage : noopStorage;
+
 export interface ToolsRouteViewProps {
   tools: ToolDefinition[];
   renderDetail: (toolId: ToolId) => ReactNode;
@@ -12,7 +22,21 @@ export interface ToolsRouteViewProps {
 
 export function ToolsRouteView({ tools, renderDetail }: ToolsRouteViewProps) {
   const pageScrollRef = useRef<HTMLDivElement>(null);
-  const [selectedToolId, setSelectedToolId] = useState<ToolId | null>(null);
+  const [selectedToolId, setSelectedToolId] = useState<ToolId | null>(() => {
+    const storedToolId = getToolStorage().getItem(SELECTED_TOOL_STORAGE_KEY);
+    return tools.some((tool) => tool.id === storedToolId) ? (storedToolId as ToolId) : null;
+  });
+
+  const setSelectedTool = (toolId: ToolId | null) => {
+    setSelectedToolId(toolId);
+    const storage = getToolStorage();
+
+    if (toolId) {
+      storage.setItem(SELECTED_TOOL_STORAGE_KEY, toolId);
+    } else {
+      storage.removeItem(SELECTED_TOOL_STORAGE_KEY);
+    }
+  };
 
   const scrollToTop = () => {
     window.requestAnimationFrame(() => {
@@ -21,12 +45,12 @@ export function ToolsRouteView({ tools, renderDetail }: ToolsRouteViewProps) {
   };
 
   const handleSelectTool = (toolId: ToolId) => {
-    setSelectedToolId(toolId);
+    setSelectedTool(toolId);
     scrollToTop();
   };
 
   const handleBackToOverview = () => {
-    setSelectedToolId(null);
+    setSelectedTool(null);
     scrollToTop();
   };
 


### PR DESCRIPTION
## 变更说明

修复工具页面在侧边栏来回切换后丢失当前工具详情的问题。

### 问题

进入某个工具详情页后，如果点击左侧侧边栏切换到其他页面，再点击“工具”返回，会回到工具首页，而不是之前正在使用的工具详情页。

这在工具执行过程中比较影响体验，例如批量翻译过程中切出去再回来，会丢失当前工具详情视图。

### 修复

在工具页中记录最近打开的工具 ID：

- 进入某个工具详情时保存当前工具。
- 再次进入工具页时恢复到上次打开的工具详情。
- 用户点击工具详情左上角返回按钮时，清除记录并回到工具首页。