### PR TITLE
Feat(crawler): 新增对fantia.jp站点的支持

### DIFF
--- a/packages/runtime/src/crawler/registry.ts
+++ b/packages/runtime/src/crawler/registry.ts
@@ -7,6 +7,7 @@ import { crawlerRegistration as dahliaRegistration } from "./sites/dahlia";
 import { crawlerRegistration as dmmRegistration } from "./sites/dmm";
 import { crawlerRegistration as dmmTvRegistration } from "./sites/dmm/dmm_tv";
 import { crawlerRegistration as falenoRegistration } from "./sites/faleno";
+import { crawlerRegistration as fantiaRegistration } from "./sites/fantia";
 import { crawlerRegistration as fc2Registration } from "./sites/fc2";
 import { crawlerRegistration as fc2hubRegistration } from "./sites/fc2hub";
 import { crawlerRegistration as h0930Registration } from "./sites/h0930";
@@ -51,6 +52,7 @@ const crawlerRegistrations: CrawlerRegistration[] = [
   dmmRegistration,
   dmmTvRegistration,
   falenoRegistration,
+  fantiaRegistration,
   fc2Registration,
   fc2hubRegistration,
   h0930Registration,

--- a/packages/runtime/src/crawler/siteConnectivity.ts
+++ b/packages/runtime/src/crawler/siteConnectivity.ts
@@ -22,6 +22,7 @@ const DEFAULT_SITE_CONNECTIVITY_URLS: Record<Website, string> = {
   [Website.DMM]: "https://www.dmm.co.jp/",
   [Website.DMM_TV]: "https://video.dmm.co.jp/",
   [Website.FALENO]: "https://faleno.jp",
+  [Website.FANTIA]: "https://fantia.jp",
   [Website.FC2]: "https://adult.contents.fc2.com",
   [Website.FC2HUB]: "https://javten.com",
   [Website.H0930]: "https://www.h0930.com",

--- a/packages/runtime/src/crawler/sites/fantia.ts
+++ b/packages/runtime/src/crawler/sites/fantia.ts
@@ -1,0 +1,310 @@
+import fs from "node:fs/promises";
+import type { SiteRequestConfig } from "@mdcz/runtime/network";
+import { normalizeCode } from "@mdcz/runtime/shared/utils";
+import { Website } from "@mdcz/shared/enums";
+import type { CrawlerData } from "@mdcz/shared/types";
+import type { CheerioAPI } from "cheerio";
+import { load } from "cheerio";
+import { BaseCrawler } from "../base/BaseCrawler";
+import { parseDate } from "../base/parser";
+import type { Context, SearchPageResolution } from "../base/types";
+import type { CrawlerRegistration } from "../registration";
+
+const FANTIA_BASE_URL = "https://fantia.jp";
+const FANTIA_SITE_REQUEST_CONFIGS: readonly SiteRequestConfig[] = [
+  {
+    id: "crawler:fantia",
+    matches: (url) => url.hostname === "fantia.jp" || url.hostname.endsWith(".fantia.jp"),
+    headers: {
+      referer: `${FANTIA_BASE_URL}/`,
+      "accept-language": "zh-CN,zh;q=0.9",
+    },
+  },
+];
+
+interface FantiaPostApiResponse {
+  post: {
+    comment: string;
+    blog_comment: string;
+  };
+}
+
+const isAgeVerificationPage = ($: CheerioAPI): boolean => {
+  const ageConfirmTitle = $(".list-group-item-title").first().text().trim();
+  if (ageConfirmTitle.includes("あなたは18歳以上ですか？")) {
+    return true;
+  }
+
+  const ageConfirmText = $(".age-confirmation-text").first().text().trim();
+  if (ageConfirmText.includes("成人向けの画像、動画、テキストなどが表示される可能性があります")) {
+    return true;
+  }
+
+  const confirmButton = $("input[value*='続行'], input[value*='はい、18歳以上です']").length > 0;
+  if (confirmButton) {
+    return true;
+  }
+
+  return false;
+};
+
+const getJsonLdValue = ($: CheerioAPI, key: string): string | undefined => {
+  const scripts = $('script[type="application/ld+json"]');
+
+  for (const script of scripts) {
+    try {
+      const htmlContent = $(script).html();
+      if (htmlContent !== null) {
+        const parsed = JSON.parse(htmlContent);
+        const items = Array.isArray(parsed) ? parsed : [parsed];
+        for (const item of items) {
+          if (item && item[key] !== undefined && item[key] !== null) {
+            return String(item[key]);
+          }
+        }
+      }
+    } catch (_e) {}
+  }
+
+  return undefined;
+};
+
+const getMainImage = ($: CheerioAPI): string | undefined => {
+  const ogImage = $('meta[property="og:image"]').attr("content") || "";
+  return ogImage.replace("blurred_ogp", "main");
+};
+
+const getProductPlot = ($: CheerioAPI): string | undefined => {
+  const plot = $(".product-description").first().text().trim();
+  return plot;
+};
+
+const normalizeNumber = (value: string | undefined | null): string => {
+  const normalized = normalizeCode(value);
+  const fantiaMatch = normalized.match(/FANTIA(\d{5,7})/);
+  if (fantiaMatch) {
+    return fantiaMatch[1];
+  }
+  const codeMatch = normalized.match(/([A-Z]{3,6})(\d{2,5})/);
+  if (codeMatch) {
+    return codeMatch[1] + codeMatch[2];
+  }
+  return normalized;
+};
+
+const _saveDebugHtml = async (filePath: string, html: string) => {
+  try {
+    await fs.writeFile(filePath, html);
+    console.log(`save success: ${filePath}`);
+  } catch (error) {
+    console.error(`save fail: ${error}`);
+  }
+};
+
+const getCsrfToken = ($: CheerioAPI): string => {
+  return $('meta[name="csrf-token"]').attr("content") || "";
+};
+
+const extractImagesFromBlogComment = (data: FantiaPostApiResponse): string[] => {
+  const images: string[] = [];
+  try {
+    const apiData = JSON.parse(data.post.blog_comment);
+    const operations = apiData.ops as Array<{ insert?: { fantiaImage?: { url?: string } } }>;
+    if (!operations) return images;
+
+    for (const operation of operations) {
+      const imageEmbed = operation.insert?.fantiaImage;
+      if (imageEmbed?.url) {
+        images.push(imageEmbed.url);
+      }
+    }
+  } catch {
+    // apiData is not valid JSON or has unexpected structure
+  }
+  return images;
+};
+
+export class FantiaCrawler extends BaseCrawler {
+  static readonly siteRequestConfigs = FANTIA_SITE_REQUEST_CONFIGS;
+
+  site(): Website {
+    return Website.FANTIA;
+  }
+
+  private async tryDirectUrl(urlpath: string, context: Context): Promise<string | null> {
+    const url = `${FANTIA_BASE_URL}${urlpath}`;
+    try {
+      const html = await this.fetch(url, context);
+      const $ = load(html);
+      const title = $("title").text().trim();
+      if (title && !title.includes("検索") && !title.includes("ログイン｜ファンティア[Fantia]")) {
+        return url;
+      }
+    } catch {
+      this.logger.debug(`Failed to fetch direct URL: ${url}`);
+    }
+    return null;
+  }
+
+  private async searchForUrl(number: string, urlpath: string, context: Context): Promise<string | null> {
+    const url = `${FANTIA_BASE_URL}${urlpath}?brand_type=0&category=&keyword=${encodeURIComponent(number)}`;
+    try {
+      const html = await this.fetch(url, context);
+      const $ = load(html);
+      const title = $("title").text().trim();
+      if (!title || title.includes("ログイン｜ファンティア[Fantia]")) {
+        return null;
+      }
+      const href = $("a.link-block").attr("href");
+      if (href) {
+        const fullUrl = `${FANTIA_BASE_URL}${href}`;
+        return fullUrl;
+      }
+    } catch {
+      this.logger.debug(`Failed to fetch search URL: ${url}`);
+    }
+    return null;
+  }
+
+  private async injectPostApiDataIntoDoc($: CheerioAPI, searchUrl: string, context: Context): Promise<void> {
+    const postIdMatch = searchUrl.match(/\/posts\/(\d+)/);
+    if (!postIdMatch) {
+      return;
+    }
+    const postId = postIdMatch[1];
+    const apiUrl = `${FANTIA_BASE_URL}/api/v1/posts/${postId}`;
+    const csrfToken = getCsrfToken($);
+
+    try {
+      const data = await this.gateway.fetchJson<FantiaPostApiResponse>(apiUrl, {
+        ...this.createFetchOptions(context),
+        headers: {
+          ...this.buildHeaders(context),
+          "X-Requested-With": "XMLHttpRequest",
+          "X-CSRF-Token": csrfToken,
+        },
+      });
+
+      const images = extractImagesFromBlogComment(data);
+
+      const $body = $("body");
+      if ($body.length > 0) {
+        if (images.length > 0) {
+          $body.append(`<div id="crawler-post-images" style="display:none">${JSON.stringify(images)}</div>`);
+        }
+        if (data.post.comment) {
+          $body.append(`<div id="crawler-post-plot" style="display:none">${JSON.stringify(data.post.comment)}</div>`);
+        }
+      }
+    } catch (error) {
+      this.logger.debug(`Failed to inject post API data for ${postId}: ${error}`);
+    }
+  }
+
+  protected async generateSearchUrl(context: Context): Promise<string | null> {
+    const number = normalizeNumber(context.number);
+    if (!number) {
+      return null;
+    }
+
+    const directPaths = [`/products/${number}`, `/posts/${number}`];
+    for (const urlpath of directPaths) {
+      const result = await this.tryDirectUrl(urlpath, context);
+      if (result) {
+        return result;
+      }
+    }
+
+    const searchPaths = [`/products`, `/posts`];
+    for (const urlpath of searchPaths) {
+      const result = await this.searchForUrl(number, urlpath, context);
+      if (result) {
+        return result;
+      }
+    }
+
+    return null;
+  }
+
+  protected async parseSearchPage(
+    context: Context,
+    $: CheerioAPI,
+    searchUrl: string,
+  ): Promise<string | SearchPageResolution | null> {
+    if (isAgeVerificationPage($)) {
+      this.logger.debug("Fantia age verification detected; please login first via browser and provide cookies");
+      throw new Error("Fantia age verification detected; please login first via browser and provide cookies");
+    }
+
+    await this.injectPostApiDataIntoDoc($, searchUrl, context);
+
+    return this.reuseSearchDocument(searchUrl);
+  }
+
+  protected async parseDetailPage(context: Context, $: CheerioAPI, _detailUrl: string): Promise<CrawlerData | null> {
+    this.logger.debug(`url is ${_detailUrl}`);
+    // saveDebugHtml(path.join(DebugHtmlDir, `fantia_${Date.now()}.html`), $.html());
+    const number = context.number;
+    const publisher = getJsonLdValue($, "fanclub_name");
+    if (!publisher) {
+      return null;
+    }
+    const actors: string[] = [];
+    const tagsRaw = getJsonLdValue($, "tag");
+    const tags = tagsRaw ? tagsRaw.split(",").map((tag) => tag.trim()) : [];
+    const fanclubCategory = getJsonLdValue($, "fanclub_category");
+    if (fanclubCategory && !tags.includes(fanclubCategory)) {
+      tags.push(fanclubCategory);
+    }
+    const thumbUrl = getMainImage($);
+    if (!thumbUrl) {
+      return null;
+    }
+
+    let title: string;
+    let releaseDate: string | undefined;
+    let plot: string | undefined;
+    let allSceneImages: string[];
+
+    if (_detailUrl.includes("/products")) {
+      title = $(".product-title.mb-20").text().trim() || "";
+      releaseDate = parseDate(getJsonLdValue($, "uploadDate"));
+      plot = getProductPlot($);
+      const galleryImages: string[] = [];
+      $(".product-gallery-item img").each((_i, el) => {
+        const src = $(el).attr("src");
+        if (src?.endsWith(".jpg")) {
+          galleryImages.push(src);
+        }
+      });
+      allSceneImages = [...new Set([thumbUrl, ...galleryImages])];
+    } else if (_detailUrl.includes("/posts")) {
+      title = getJsonLdValue($, "headline") || "";
+      releaseDate = parseDate(getJsonLdValue($, "datePublished"));
+      const plotEl = $("#crawler-post-plot");
+      plot = plotEl.length > 0 ? JSON.parse(plotEl.text()) : getJsonLdValue($, "description");
+      const imgEl = $("#crawler-post-images");
+      allSceneImages = imgEl.length > 0 ? JSON.parse(imgEl.text()) : [thumbUrl];
+    } else {
+      return null;
+    }
+
+    return {
+      title,
+      number,
+      actors,
+      genres: tags,
+      publisher,
+      plot,
+      release_date: releaseDate,
+      thumb_url: thumbUrl,
+      scene_images: allSceneImages,
+      website: Website.FANTIA,
+    };
+  }
+}
+
+export const crawlerRegistration: CrawlerRegistration = {
+  site: Website.FANTIA,
+  crawler: FantiaCrawler,
+};

--- a/packages/runtime/src/network/cookieChecks.ts
+++ b/packages/runtime/src/network/cookieChecks.ts
@@ -117,14 +117,44 @@ const checkJavbusCookie = async (
   }
 };
 
+const checkFantiaCookie = async (
+  cookie: string,
+  networkClient: CookieCheckNetworkClient,
+): Promise<CookieCheckResult> => {
+  if (!cookie) {
+    return { site: "Fantia", valid: false, message: "未配置 Cookie", status: "not_configured" };
+  }
+
+  try {
+    const html = await networkClient.getText("https://fantia.jp/mypage/dashboard", {
+      headers: { cookie },
+    });
+    const valid = !html.includes("外部サービスでログイン");
+    return {
+      site: "Fantia",
+      valid,
+      message: valid ? "Cookie 有效" : "Cookie 无效或已过期",
+      status: valid ? "ready_with_cookie" : "invalid_or_expired",
+    };
+  } catch (error) {
+    return {
+      site: "Fantia",
+      valid: false,
+      message: `请求失败: ${toCookieSafeErrorMessage(error, cookie)}`,
+      status: "request_failed",
+    };
+  }
+};
+
 export const checkConfiguredSiteCookies = async (
   configuration: Configuration,
   networkClient: CookieCheckNetworkClient,
 ): Promise<{ results: CookieCheckResult[] }> => {
-  const [javdb, javbus] = await Promise.all([
+  const [javdb, javbus, fantia] = await Promise.all([
     checkJavdbCookie(configuration.network.javdbCookie.trim(), networkClient),
     checkJavbusCookie(configuration.network.javbusCookie.trim(), networkClient),
+    checkFantiaCookie(configuration.network.fantiaCookie.trim(), networkClient),
   ]);
 
-  return { results: [javdb, javbus] };
+  return { results: [javdb, javbus, fantia] };
 };

--- a/packages/runtime/src/runtimeActions.test.ts
+++ b/packages/runtime/src/runtimeActions.test.ts
@@ -23,7 +23,7 @@ describe("settings parity runtime helpers", () => {
     expect(buildSiteConnectivityHeaders(Website.SOKMIL, config)).toEqual({ cookie: "AGEAUTH=ok" });
   });
 
-  it("reports when JavBus is anonymously accessible while JavDB remains unconfigured", async () => {
+  it("reports when JavBus is anonymously accessible while JavDB and Fantia remains unconfigured", async () => {
     const getText = vi.fn(async () => '<a class="movie-box" href="/ABP-123"></a>');
 
     await expect(checkConfiguredSiteCookies(cloneConfig(), { getText })).resolves.toEqual({
@@ -35,6 +35,7 @@ describe("settings parity runtime helpers", () => {
           message: "JavBus 影片页面可匿名访问，无需 Cookie",
           status: "ready_without_cookie",
         },
+        { site: "Fantia", valid: false, message: "未配置 Cookie", status: "not_configured" },
       ],
     });
     expect(getText).toHaveBeenCalledWith("https://www.javbus.com/", { headers: { ...JAVBUS_REQUEST_HEADERS } });

--- a/packages/runtime/src/scrape/aggregation.ts
+++ b/packages/runtime/src/scrape/aggregation.ts
@@ -466,6 +466,11 @@ const buildCrawlerOptions = ({
     options.cookies = javbusCookie;
   }
 
+  const fantiaCookie = configuration.network.fantiaCookie.trim();
+  if (site === Website.FANTIA && fantiaCookie) {
+    options.cookies = fantiaCookie;
+  }
+
   if (site === Website.R18_DEV) {
     options.r18MetadataLanguage = configuration.scrape.r18MetadataLanguage;
   }

--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -39,6 +39,7 @@ const networkSchema = z.object({
   retryCount: z.number().int().min(0).max(10).default(3),
   javdbCookie: z.string().default(""),
   javbusCookie: z.string().default(""),
+  fantiaCookie: z.string().default(""),
 });
 
 const scrapeSchema = z.object({

--- a/packages/shared/enums.ts
+++ b/packages/shared/enums.ts
@@ -3,6 +3,7 @@ export enum Website {
   DMM = "dmm",
   DMM_TV = "dmm_tv",
   FALENO = "faleno",
+  FANTIA = "fantia",
   FC2 = "fc2",
   FC2HUB = "fc2hub",
   H0930 = "h0930",

--- a/packages/shared/manualScrapeUrl.ts
+++ b/packages/shared/manualScrapeUrl.ts
@@ -135,6 +135,11 @@ const SITE_RULES: readonly ManualScrapeSiteRule[] = [
     hosts: ["avwikidb.com", "www.avwikidb.com"],
     isDetailUrl: (url) => pathMatches(url, /^\/work\/[^/]+\/?$/iu),
   },
+  {
+    site: Website.FANTIA,
+    hosts: ["fantia.jp", "www.fantia.jp"],
+    isDetailUrl: (url) => pathMatches(url, /^\/(?:products|posts)\/[^/]+\/?$/iu),
+  },
 ];
 
 const parseInputUrl = (input: string): URL | null => {

--- a/packages/shared/settingsRegistry.ts
+++ b/packages/shared/settingsRegistry.ts
@@ -202,6 +202,7 @@ const FIELD_ALIASES: Record<string, string[]> = {
   "scrape.sites": SITE_PRIORITY_EDITOR_ALIASES,
   "network.javdbCookie": ["cookie", "javdb", "凭证"],
   "network.javbusCookie": ["cookie", "javbus", "凭证"],
+  "network.fantiaCookie": ["cookie", "fantia", "凭证"],
   "translate.engine": ["translator", "translation", "翻译引擎"],
   "translate.llmModelName": ["model", "openai", "llm"],
   "translate.llmApiKey": ["api key", "token", "openai key", "密钥"],
@@ -311,6 +312,7 @@ const RAW_FIELD_REGISTRY: Array<
   { key: "network.retryCount", label: "重试次数", anchor: "network" },
   { key: "network.javdbCookie", label: "JavDB Cookie", anchor: "network" },
   { key: "network.javbusCookie", label: "JavBus Cookie", anchor: "network" },
+  { key: "network.fantiaCookie", label: "Fantia Cookie", anchor: "network" },
   ...AGGREGATION_PRIORITY_FIELDS.map((entry) => ({
     key: entry.key,
     label: entry.label,

--- a/packages/views/src/config-form/FieldRenderer.tsx
+++ b/packages/views/src/config-form/FieldRenderer.tsx
@@ -342,13 +342,19 @@ export function EnumField({
 
 // ── Cookie with validation ──
 
-const COOKIE_VALIDATE_FIELDS = new Set(["network.javdbCookie", "network.javbusCookie"]);
+const COOKIE_VALIDATE_FIELDS = new Set(["network.javdbCookie", "network.javbusCookie", "network.fantiaCookie"]);
 
 function CookieValidateButton({ fieldKey }: { fieldKey: string }) {
   const services = useSettingsServices();
   const [checking, setChecking] = useState(false);
   const [result, setResult] = useState<{ valid: boolean; message: string } | null>(null);
-  const siteName = fieldKey.includes("javdb") ? "JavDB" : "JavBus";
+  const siteName = fieldKey.includes("javdb")
+    ? "JavDB"
+    : fieldKey.includes("javbus")
+      ? "JavBus"
+      : fieldKey.includes("fantia")
+        ? "Fantia"
+        : "Unknown";
 
   const handleCheck = async () => {
     setChecking(true);

--- a/packages/views/src/settings/SiteConnectivityPill.tsx
+++ b/packages/views/src/settings/SiteConnectivityPill.tsx
@@ -34,12 +34,26 @@ export function SiteConnectivityPill({ site }: SiteConnectivityPillProps) {
   const hasMountedRef = useRef(false);
   const requestVersionRef = useRef(0);
 
-  const [proxyType, proxy, useProxy, javdbCookie, javbusCookie] =
+  const [proxyType, proxy, useProxy, javdbCookie, javbusCookie, fantiaCookie] =
     (useWatch({
       control: form.control,
-      name: ["network.proxyType", "network.proxy", "network.useProxy", "network.javdbCookie", "network.javbusCookie"],
-    }) as [string | undefined, string | undefined, boolean | undefined, string | undefined, string | undefined]) ?? [];
-  const probeDependencyKey = [proxyType, proxy, useProxy, javdbCookie, javbusCookie].join("::");
+      name: [
+        "network.proxyType",
+        "network.proxy",
+        "network.useProxy",
+        "network.javdbCookie",
+        "network.javbusCookie",
+        "network.fantiaCookie",
+      ],
+    }) as [
+      string | undefined,
+      string | undefined,
+      boolean | undefined,
+      string | undefined,
+      string | undefined,
+      string | undefined,
+    ]) ?? [];
+  const probeDependencyKey = [proxyType, proxy, useProxy, javdbCookie, javbusCookie, fantiaCookie].join("::");
 
   useEffect(() => {
     void probeDependencyKey;

--- a/packages/views/src/settings/settingsContent.tsx
+++ b/packages/views/src/settings/settingsContent.tsx
@@ -348,6 +348,7 @@ export function NetworkCookiesSection() {
     <>
       <CookieFieldWrapper name="network.javdbCookie" label="JavDB Cookie" />
       <CookieFieldWrapper name="network.javbusCookie" label="JavBus Cookie" />
+      <CookieFieldWrapper name="network.fantiaCookie" label="Fantia Cookie" />
     </>
   );
 }

--- a/packages/views/src/settings/sitePriorityOptions.ts
+++ b/packages/views/src/settings/sitePriorityOptions.ts
@@ -114,6 +114,12 @@ const SITE_PRIORITY_OPTION_DEFINITIONS: SitePriorityOptionDefinition[] = [
     sites: [Website.KINGDOM],
     aliases: ["empress", "princess", "queen", "bambini"],
   },
+  {
+    id: Website.FANTIA,
+    label: Website.FANTIA,
+    description: "Fantia 官方站点，适合 Fantia 编号作品，通用性较低。",
+    sites: [Website.FANTIA],
+  },
 ];
 
 export const SITE_PRIORITY_EDITOR_ALIASES = Array.from(

--- a/tests/unit/services/crawler/fantia.test.ts
+++ b/tests/unit/services/crawler/fantia.test.ts
@@ -1,0 +1,203 @@
+import { FantiaCrawler } from "@mdcz/runtime/crawler/sites/fantia";
+import { Website } from "@mdcz/shared/enums";
+import { describe, expect, it } from "vitest";
+
+import { FixtureNetworkClient, withGateway } from "./fixtures";
+
+describe("FantiaCrawler", () => {
+  it("parses product pages correctly", async () => {
+    const cases = [
+      {
+        number: "1035215",
+        searchUrl: "https://fantia.jp/products/1035215",
+        searchHtml: `
+          <html><head>
+            <title>title of 1035215 | fantia</title>
+            <meta property="og:image" content="https://c.fantia.jp/uploads/product/image/1035215/blurred_ogp_76b94de1-c692-457f-945a-27b8ee248532.jpg" />
+            <script
+              type="application/ld+json">[{"@type":"Product","@context":"https://schema.org","name":"name of 1035215","description":"description of 1035215","image":["https://c.fantia.jp/uploads/product/image/1035215/76b94de1-c692-457f-945a-27b8ee248532.jpg","https://c.fantia.jp/uploads/product_image/file/916294/micro_3a276866_Frame_93.jpg","https://c.fantia.jp/uploads/product_image/file/916295/micro_88a0cef4_Frame_87.jpg","https://c.fantia.jp/uploads/product_image/file/916296/micro_25beb2e3_Frame_88.jpg"],"brand":{"@type":"Brand","name":"hakuのファンティア"},"offers":{"@type":"Offer","price":400,"priceCurrency":"JPY","url":"https://fantia.jp/products/1035215","availability":"https://schema.org/InStock"}}]</script>
+          </head><body>
+            <script class="gtm-json"
+              type="application/ld+json">{"fanclub_id":501856,"fanclub_brand":"男性向け","fanclub_category":"漫画","fanclub_name":"fanclub_name of 1035215","fanclub_user_name":"fanclub_user_name of 1035215","content_title":"content title of 1035215","content_type":"product","content_id":1035215}</script>
+            <div class="product-gallery-item"><img class="img-fluid lazyload " alt="title of 1035215"
+                src="https://c.fantia.jp/uploads/product_image/file/916294/main_3a276866_Frame_93.jpg"></div>
+            <div class="product-gallery-item"><img class="img-fluid lazyload " alt="title of 1035215"
+                src="https://c.fantia.jp/uploads/product_image/file/916295/main_88a0cef4_Frame_87.jpg"></div>
+            <div class="product-gallery-item"><img class="img-fluid lazyload " alt="title of 1035215"
+                src="https://c.fantia.jp/uploads/product_image/file/916296/main_25beb2e3_Frame_88.jpg"></div>
+            </div>
+            <div class="product-description">
+              <h3 class="content-title"></h3>
+              <div class="mb-30">
+                <p>product-description of 1035215</p>
+              </div>
+            </div>
+            <h1 class="product-title mb-20">title of 1035215</h1>
+          </body></html>
+        `,
+        assert: (data: Awaited<ReturnType<FantiaCrawler["crawl"]>>) => {
+          if (!data.result.success) throw new Error("expected success");
+          expect(data.result.data.website).toBe(Website.FANTIA);
+          expect(data.result.data.number).toBe("1035215");
+          expect(data.result.data.title).toBe("title of 1035215");
+          expect(data.result.data.actors).toEqual([]);
+          expect(data.result.data.genres).toEqual(["漫画"]);
+          expect(data.result.data.publisher).toBe("fanclub_name of 1035215");
+          // expect(data.result.data.release_date).toBe("2024-01-15");
+          expect(data.result.data.thumb_url).toBe(
+            "https://c.fantia.jp/uploads/product/image/1035215/main_76b94de1-c692-457f-945a-27b8ee248532.jpg",
+          );
+          expect(data.result.data.plot).toBe("product-description of 1035215");
+          expect(data.result.data.scene_images).toEqual([
+            "https://c.fantia.jp/uploads/product/image/1035215/main_76b94de1-c692-457f-945a-27b8ee248532.jpg",
+            "https://c.fantia.jp/uploads/product_image/file/916294/main_3a276866_Frame_93.jpg",
+            "https://c.fantia.jp/uploads/product_image/file/916295/main_88a0cef4_Frame_87.jpg",
+            "https://c.fantia.jp/uploads/product_image/file/916296/main_25beb2e3_Frame_88.jpg",
+          ]);
+        },
+      },
+    ];
+
+    for (const { number, searchUrl, searchHtml, assert } of cases) {
+      const fixtures = new Map<string, string>([[searchUrl, searchHtml]]);
+      const crawler = new FantiaCrawler(withGateway(new FixtureNetworkClient(fixtures)));
+
+      const response = await crawler.crawl({ number, site: Website.FANTIA });
+
+      expect(response.result.success).toBe(true);
+      assert(response as Awaited<ReturnType<FantiaCrawler["crawl"]>>);
+    }
+  });
+
+  it("parses post pages with API data injection", async () => {
+    const number = "4155703";
+    const searchUrl = "https://fantia.jp/posts/4155703";
+    const apiUrl = "https://fantia.jp/api/v1/posts/4155703";
+
+    const searchHtml = `
+      <html><head>
+        <title>title of 4155703</title>
+        <meta name="csrf-token"
+          content="test-csrf-token">
+        <meta property="og:image" content="https://c.fantia.jp/uploads/post/file/4155703/blurred_ogp_ff86c9f5-8755-4f59-b67a-be3e7d826a1f.jpg" />
+        <script
+          type="application/ld+json">{"@type":"Article","@context":"https://schema.org","datePublished":"2026-07-21T19:36:00+09:00","dateModified":"2026-07-21T19:36:36+09:00","headline":"headline of 4155703","description":"description of 4155703","mainEntityOfPage":"https://fantia.jp/posts/4155703","image":"https://c.fantia.jp/uploads/fanclub/icon_image/491009/thumb_fa862b71-4ce8-4aac-be56-270ad182c150.png","author":{"@type":"Person","name":"name of 4155703","url":"https://fantia.jp/fanclubs/491009","sameAs":["https://x.com/rena_hlive","https://www.youtube.com/@renachankapaana","https://nicochannel.jp/renahliveasmr/","https://lit.link/renabesuteahlive"]},"publisher":{"@type":"Organization","name":"name of 4155703","logo":{"@type":"ImageObject","url":"https://fantia.jp/assets/customers/ogp-a43eda907aaba5783458b8036f8e5873e4b07a4284f778612809580dcd28353e.jpg"}}}</script>
+      </head><body>
+        <script class="gtm-json"
+          type="application/ld+json">{"fanclub_id":491009,"fanclub_brand":"男性向け","fanclub_category":"VTuber","fanclub_name":"fanclub_name of 4155703","fanclub_user_name":"fanclub_user_name of 4155703","content_title":"content title of 4155703","content_type":"post","content_id":4155703,"tag":["vtuber声優","ASMR"]}</script>
+      </body></html>
+    `;
+
+    const apiResponse = {
+      post: {
+        comment: "Full post body text with complete content that is not truncated.",
+        blog_comment: JSON.stringify({
+          ops: [
+            { insert: "Some text\n" },
+            { insert: { fantiaImage: { url: "https://cc.fantia.jp/uploads/album_image/file/1/main_image1.jpg" } } },
+            { insert: "More text\n" },
+            { insert: { fantiaImage: { url: "https://cc.fantia.jp/uploads/album_image/file/2/main_image2.jpg" } } },
+          ],
+        }),
+      },
+    };
+
+    const fixtures = new Map<string, unknown>([
+      [searchUrl, searchHtml],
+      [apiUrl, apiResponse],
+    ]);
+    const crawler = new FantiaCrawler(withGateway(new FixtureNetworkClient(fixtures)));
+
+    const response = await crawler.crawl({ number, site: Website.FANTIA });
+
+    expect(response.result.success).toBe(true);
+    if (!response.result.success) throw new Error("expected success");
+
+    expect(response.result.data.website).toBe(Website.FANTIA);
+    expect(response.result.data.number).toBe("4155703");
+    expect(response.result.data.title).toBe("headline of 4155703");
+    expect(response.result.data.actors).toEqual([]);
+    expect(response.result.data.genres).toEqual(["vtuber声優", "ASMR", "VTuber"]);
+    expect(response.result.data.publisher).toBe("fanclub_name of 4155703");
+    expect(response.result.data.release_date).toBe("2026-07-21");
+    expect(response.result.data.thumb_url).toBe(
+      "https://c.fantia.jp/uploads/post/file/4155703/main_ff86c9f5-8755-4f59-b67a-be3e7d826a1f.jpg",
+    );
+
+    // Full plot from API comment, not truncated JSON-LD
+    expect(response.result.data.plot).toBe("Full post body text with complete content that is not truncated.");
+
+    // scene_images from blog_comment fantiaImage entries
+    expect(response.result.data.scene_images).toEqual([
+      "https://cc.fantia.jp/uploads/album_image/file/1/main_image1.jpg",
+      "https://cc.fantia.jp/uploads/album_image/file/2/main_image2.jpg",
+    ]);
+  });
+
+  it("falls back to JSON-LD data when API injection fails for posts", async () => {
+    const number = "4155703";
+    const searchUrl = "https://fantia.jp/posts/4155703";
+
+    const searchHtml = `
+      <html><head>
+        <title>title of 4155703</title>
+        <meta name="csrf-token"
+          content="test-csrf-token">
+        <meta property="og:image" content="https://c.fantia.jp/uploads/post/file/4155703/blurred_ogp_ff86c9f5-8755-4f59-b67a-be3e7d826a1f.jpg" />
+        <script
+          type="application/ld+json">{"@type":"Article","@context":"https://schema.org","datePublished":"2026-07-21T19:36:00+09:00","dateModified":"2026-07-21T19:36:36+09:00","headline":"headline of 4155703","description":"description of 4155703","mainEntityOfPage":"https://fantia.jp/posts/4155703","image":"https://c.fantia.jp/uploads/fanclub/icon_image/491009/thumb_fa862b71-4ce8-4aac-be56-270ad182c150.png","author":{"@type":"Person","name":"name of 4155703","url":"https://fantia.jp/fanclubs/491009","sameAs":["https://x.com/rena_hlive","https://www.youtube.com/@renachankapaana","https://nicochannel.jp/renahliveasmr/","https://lit.link/renabesuteahlive"]},"publisher":{"@type":"Organization","name":"name of 4155703","logo":{"@type":"ImageObject","url":"https://fantia.jp/assets/customers/ogp-a43eda907aaba5783458b8036f8e5873e4b07a4284f778612809580dcd28353e.jpg"}}}</script>
+      </head><body>
+        <script class="gtm-json"
+          type="application/ld+json">{"fanclub_id":491009,"fanclub_brand":"男性向け","fanclub_category":"VTuber","fanclub_name":"fanclub_name of 4155703","fanclub_user_name":"fanclub_user_name of 4155703","content_title":"content title of 4155703","content_type":"post","content_id":4155703,"tag":["vtuber声優","ASMR"]}</script>
+      </body></html>
+    `;
+
+    const fixtures = new Map<string, string>([[searchUrl, searchHtml]]);
+    const crawler = new FantiaCrawler(withGateway(new FixtureNetworkClient(fixtures)));
+
+    const response = await crawler.crawl({ number, site: Website.FANTIA });
+
+    expect(response.result.success).toBe(true);
+    if (!response.result.success) throw new Error("expected success");
+
+    // Falls back to JSON-LD description (truncated)
+    expect(response.result.data.plot).toBe("description of 4155703");
+
+    // Falls back to thumb-only scene_images
+    expect(response.result.data.scene_images).toEqual([
+      "https://c.fantia.jp/uploads/post/file/4155703/main_ff86c9f5-8755-4f59-b67a-be3e7d826a1f.jpg",
+    ]);
+  });
+
+  it("returns an explicit error when Fantia serves the age verification page", async () => {
+    const number = "99999";
+    const productsUrl = "https://fantia.jp/products/99999";
+
+    const ageVerifyHtml = `
+      <html><head><title>Fantia</title></head><body>
+        <div class="list-group-item-title">あなたは18歳以上ですか？</div>
+      </body></html>
+    `;
+
+    const fixtures = new Map<string, string>([[productsUrl, ageVerifyHtml]]);
+    const crawler = new FantiaCrawler(withGateway(new FixtureNetworkClient(fixtures)));
+
+    const response = await crawler.crawl({ number, site: Website.FANTIA });
+
+    expect(response.result.success).toBe(false);
+    if (response.result.success) throw new Error("expected failure");
+    expect(response.result.error).toContain("age verification");
+  });
+
+  it("returns an error when neither products nor posts URL resolves", async () => {
+    const number = "00000";
+    const fixtures = new Map<string, string>([]);
+    const crawler = new FantiaCrawler(withGateway(new FixtureNetworkClient(fixtures)));
+
+    const response = await crawler.crawl({ number, site: Website.FANTIA });
+
+    expect(response.result.success).toBe(false);
+    if (response.result.success) throw new Error("expected failure");
+    expect(response.result.failureReason).toBe("not_found");
+  });
+});


### PR DESCRIPTION
## 关联Issue
Closes #66

## 主要文件修改
新增 mdcz/packages/runtime/src/crawler/sites/fantia.ts
新增 mdcz/tests/unit/services/crawler/fantia.test.ts
新增 mdcz/packages/runtime/src/network/cookieChecks.ts的checkFantiaCookie段

## 本地测试通过
pnpm typecheck
npx vitest run --project unit tests/unit/services/crawler/registry.test.ts tests/unit/services/crawler/site_connectivity.test.ts tests/unit/services/crawler/fantia.test.ts tests/unit/services/scraper/aggregation_service.unit.test.ts tests/unit/ipc/scraper_manual_url.test.ts tests/unit/utils/nfo.test.ts