### PR TITLE
feat: start crawler fixture recording

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -11,7 +11,7 @@ import { TrayService } from "@main/services/TrayService";
 import { UpdateService } from "@main/services/UpdateService";
 import { type MainWindowCreationOptions, WindowService } from "@main/services/WindowService";
 import { shouldRunStartupUpdateCheck } from "@main/updateCheckPolicy";
-import { NetworkClient } from "@mdcz/runtime/network";
+import { createCrawlerNetworkClient, finalizeCrawlerRecording } from "@mdcz/runtime/network";
 import { runtimeLoggerService } from "@mdcz/runtime/shared";
 import { app, BrowserWindow } from "electron";
 
@@ -20,7 +20,7 @@ const QUIT_FORCE_EXIT_TIMEOUT_MS = 15_000;
 runtimeLoggerService.setFactory((name) => loggerService.getLogger(name));
 
 const signalService = new SignalService();
-const sharedNetworkClient = new NetworkClient({
+const sharedNetworkClient = createCrawlerNetworkClient({
   getProxyUrl: () => configManager.getComputed().proxyUrl,
   getTimeoutMs: () => configManager.getComputed().networkTimeoutMs,
   getRetryCount: () => configManager.getComputed().networkRetryCount,
@@ -98,6 +98,7 @@ const cleanupResources = async (): Promise<void> => {
   cleanupPromise = (async () => {
     const logger = loggerService.getLogger("Main");
     try {
+      await finalizeCrawlerRecording();
       await serviceContainer?.shutdown();
     } catch (error) {
       const message = error instanceof Error ? (error.stack ?? error.message) : String(error);

--- a/apps/desktop/src/main/services/scraper/ScraperService.ts
+++ b/apps/desktop/src/main/services/scraper/ScraperService.ts
@@ -14,7 +14,7 @@ import type { PersistentCooldownStore } from "@mdcz/runtime/cooldown";
 import type { CrawlerProvider } from "@mdcz/runtime/crawler";
 import { type ConfiguredMediaRootService, mediaPathOwnership } from "@mdcz/runtime/library";
 import { buildMovieTags } from "@mdcz/runtime/maintenance";
-import type { NetworkClient } from "@mdcz/runtime/network";
+import { attachCrawlerRecordingCaseId, type NetworkClient } from "@mdcz/runtime/network";
 import { commitScrapeTerminalResult, type ScrapeFileTransitions } from "@mdcz/runtime/publication";
 import type { ScrapeExecutionMode } from "@mdcz/runtime/scrape";
 import {
@@ -352,7 +352,7 @@ export class ScraperService {
             }
           }
         }
-        return {
+        return attachCrawlerRecordingCaseId({
           id: item.id,
           rootId: item.rootId,
           relativePath: item.relativePath,
@@ -360,7 +360,7 @@ export class ScraperService {
           ...(executionSource ? { executionSource } : {}),
           ...(retrying ? { replaceExistingTargets: true } : {}),
           ...(retrying ? { outputBaseDirectory: resolveRootRelativePath(outputRoot, "") } : {}),
-        };
+        });
       }),
     );
     const itemIndexById = new Map(items.map((item, index) => [item.id, index + 1]));

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import type { ActorSourceProvider } from "@mdcz/runtime/actorSource";
 import { PersistentCooldownStore } from "@mdcz/runtime/cooldown";
 import { CrawlerProvider, FetchGateway } from "@mdcz/runtime/crawler";
-import { NetworkClient } from "@mdcz/runtime/network";
+import { createCrawlerNetworkClient, type NetworkClient } from "@mdcz/runtime/network";
 import { ActorImageService } from "@mdcz/runtime/scrape";
 import { runtimeLoggerService } from "@mdcz/runtime/shared";
 import type { FileTranslationMappingStore } from "@mdcz/runtime/translate";
@@ -94,7 +94,7 @@ export const buildServer = (options: BuildServerOptions = {}): ServerApp => {
   const mappingStore = options.resources?.mappingStore ?? createServerTranslationMappingStore(config);
   const networkClient =
     options.resources?.networkClient ??
-    new NetworkClient({
+    createCrawlerNetworkClient({
       getProxyUrl: () => config.getComputed().proxyUrl,
       getTimeoutMs: () => config.getComputed().networkTimeoutMs,
       getRetryCount: () => config.getComputed().networkRetryCount,

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,3 +1,4 @@
+import { finalizeCrawlerRecording } from "@mdcz/runtime/network";
 import { buildServer } from "./app";
 import { parseHost, parsePort } from "./config";
 
@@ -7,6 +8,7 @@ const startServer = async (): Promise<void> => {
   const { fastify } = buildServer();
 
   const shutdown = async (): Promise<void> => {
+    await finalizeCrawlerRecording();
     await fastify.close();
   };
 

--- a/apps/server/src/services/scrapeService.ts
+++ b/apps/server/src/services/scrapeService.ts
@@ -7,7 +7,7 @@ import type { PersistentCooldownStore } from "@mdcz/runtime/cooldown";
 import { mediaPathOwnership, toLibraryAssets } from "@mdcz/runtime/library";
 import { buildMovieTags, LocalScanService } from "@mdcz/runtime/maintenance";
 import { MaintenanceArtifactResolver } from "@mdcz/runtime/maintenance/MaintenanceArtifactResolver";
-import type { NetworkClient } from "@mdcz/runtime/network";
+import { attachCrawlerRecordingCaseId, type NetworkClient } from "@mdcz/runtime/network";
 import {
   commitPublishedMedia,
   commitRegisteredPublication,
@@ -583,7 +583,7 @@ export class ScrapeService {
             }
           }
         }
-        return {
+        return attachCrawlerRecordingCaseId({
           id: item.id,
           rootId: item.rootId,
           relativePath: item.relativePath,
@@ -594,7 +594,7 @@ export class ScrapeService {
           ...(retrying && requestedOutputRoot
             ? { outputBaseDirectory: resolveRootRelativePath(requestedOutputRoot, "") }
             : {}),
-        };
+        });
       }),
     );
     return {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "test:coverage:desktop": "vitest run --config vitest.desktop-coverage.config.ts --coverage --silent",
     "test:e2e": "node tests/e2e/web/run.mjs",
     "test:live": "node tests/live/run-live.mjs",
+    "record:webui": "node tests/recording/run.mjs webui",
+    "record:desktop": "node tests/recording/run.mjs desktop",
+    "record:publish": "node tests/recording/publish.mjs",
     "typecheck": "tsc -b --pretty false",
     "typecheck:apps": "pnpm --filter @mdcz/server --filter @mdcz/web typecheck",
     "format": "biome check --write"

--- a/packages/runtime/src/network/CrawlerRecordNetworkClient.test.ts
+++ b/packages/runtime/src/network/CrawlerRecordNetworkClient.test.ts
@@ -1,0 +1,231 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { CrawlerReplayNetworkClient } from "@mdcz/runtime/network";
+import { Website } from "@mdcz/shared/enums";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CrawlerRecordNetworkClient } from "./CrawlerRecordNetworkClient";
+import { loadCrawlerCassette } from "./crawlerCassette";
+import { runWithCrawlerSourceContext, runWithScrapeItemContext } from "./crawlerFixtureContext";
+import type { CrawlerRecordingPlan } from "./crawlerRecordingPlan";
+
+const { fetchMock, impitConstructorMock } = vi.hoisted(() => {
+  const fetchMock = vi.fn();
+  const impitConstructorMock = vi.fn();
+  return { fetchMock, impitConstructorMock };
+});
+
+const directories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    directories.splice(0).map(async (directory) => await rm(directory, { recursive: true, force: true })),
+  );
+});
+
+beforeEach(() => {
+  (
+    globalThis as typeof globalThis & {
+      __mdczImpitMock?: { fetch: typeof fetchMock; constructorSpy: typeof impitConstructorMock };
+    }
+  ).__mdczImpitMock = {
+    fetch: fetchMock,
+    constructorSpy: impitConstructorMock,
+  };
+  fetchMock.mockReset();
+  impitConstructorMock.mockClear();
+});
+
+const tempDir = async (label: string): Promise<string> => {
+  const directory = await mkdtemp(path.join(tmpdir(), `mdcz-${label}-`));
+  directories.push(directory);
+  return directory;
+};
+
+const PLAN: CrawlerRecordingPlan = {
+  journeyId: "representative-batch",
+  items: [
+    { relativePath: "one.mp4", caseId: "movie-one" },
+    { relativePath: "nested/two.mp4", caseId: "movie-two" },
+  ],
+};
+
+const itemOne = { itemId: "one", relativePath: "one.mp4", caseId: "movie-one" };
+const itemTwo = { itemId: "two", relativePath: "nested/two.mp4", caseId: "movie-two" };
+
+const createRecorder = async () => {
+  const stagingRoot = await tempDir("record-staging");
+  const publishRoot = await tempDir("record-publish");
+  const recorder = new CrawlerRecordNetworkClient({ stagingRoot, publishRoot, plan: PLAN });
+  return { recorder, stagingRoot, publishRoot };
+};
+
+const recorded = async <T>(item: typeof itemOne, website: Website, run: () => Promise<T>): Promise<T> =>
+  await runWithScrapeItemContext(item, async () => await runWithCrawlerSourceContext(website, run));
+
+const jpegBytes = Uint8Array.from([0xff, 0xd8, 0xff, 0xd9, 0x01, 0x02, 0x03, 0x04]);
+
+describe("CrawlerRecordNetworkClient", () => {
+  it("assigns arbitrary items by caseId and isolates concurrent website sources", async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      await new Promise((resolve) => setTimeout(resolve, 15));
+      return new Response(`body:${url}`, { status: 200, headers: { "content-type": "text/html; charset=utf-8" } });
+    });
+    const { recorder, stagingRoot } = await createRecorder();
+
+    await Promise.all([
+      recorded(itemOne, Website.DMM, async () => await recorder.getText("https://www.dmm.co.jp/one")),
+      recorded(itemOne, Website.JAVDB, async () => await recorder.getText("https://javdb.com/one")),
+      recorded(itemOne, Website.JAVBUS, async () => await recorder.getText("https://www.javbus.com/one")),
+      recorded(itemTwo, Website.DMM, async () => await recorder.getText("https://www.dmm.co.jp/two")),
+    ]);
+
+    const dmmOne = await loadCrawlerCassette(stagingRoot, Website.DMM, "movie-one");
+    const javdbOne = await loadCrawlerCassette(stagingRoot, Website.JAVDB, "movie-one");
+    const javbusOne = await loadCrawlerCassette(stagingRoot, Website.JAVBUS, "movie-one");
+    const dmmTwo = await loadCrawlerCassette(stagingRoot, Website.DMM, "movie-two");
+
+    expect(dmmOne.cassette.interactions).toHaveLength(1);
+    expect(dmmOne.cassette.interactions[0]?.request.url).toBe("https://www.dmm.co.jp/one");
+    expect(javdbOne.cassette.interactions[0]?.request.url).toBe("https://javdb.com/one");
+    expect(javbusOne.cassette.interactions[0]?.request.url).toBe("https://www.javbus.com/one");
+    expect(dmmTwo.cassette.interactions[0]?.request.url).toBe("https://www.dmm.co.jp/two");
+    expect(dmmOne.cassette.website).toBe(Website.DMM);
+    expect(javdbOne.cassette.website).toBe(Website.JAVDB);
+  });
+
+  it("does not record image downloads or other requests outside crawler source context", async () => {
+    fetchMock.mockImplementation(
+      async () => new Response("poster", { status: 200, headers: { "content-type": "image/jpeg" } }),
+    );
+    const { recorder, stagingRoot } = await createRecorder();
+
+    await recorder.getText("https://cdn.example.com/poster.jpg");
+    await runWithScrapeItemContext(itemOne, async () => await recorder.getText("https://cdn.example.com/thumb.jpg"));
+
+    await expect(loadCrawlerCassette(stagingRoot, Website.DMM, "movie-one")).rejects.toThrow();
+  });
+
+  it("stores html, json, text, and binary bodies with the original bytes and matching extensions", async () => {
+    const html = "<html><body>detail</body></html>";
+    const json = '{"title":"SSIS-497"}';
+    const text = "plain-body";
+    fetchMock
+      .mockResolvedValueOnce(new Response(html, { status: 200, headers: { "content-type": "text/html" } }))
+      .mockResolvedValueOnce(new Response(json, { status: 200, headers: { "content-type": "application/json" } }))
+      .mockResolvedValueOnce(new Response(text, { status: 200, headers: { "content-type": "text/plain" } }))
+      .mockResolvedValueOnce(
+        new Response(jpegBytes, { status: 200, headers: { "content-type": "image/jpeg", "content-length": "8" } }),
+      );
+
+    const { recorder, stagingRoot } = await createRecorder();
+    await recorded(itemOne, Website.DMM, async () => {
+      await recorder.getText("https://www.dmm.co.jp/html");
+      await recorder.getJson("https://www.dmm.co.jp/json");
+      await recorder.getText("https://www.dmm.co.jp/text");
+      await recorder.getContent("https://www.dmm.co.jp/cover.jpg");
+    });
+
+    const loaded = await loadCrawlerCassette(stagingRoot, Website.DMM, "movie-one");
+    expect(loaded.cassette.interactions.map((interaction) => interaction.response?.bodyPath)).toEqual([
+      "responses/001.html",
+      "responses/002.json",
+      "responses/003.txt",
+      "responses/004.jpg",
+    ]);
+    expect(Buffer.from(loaded.responseBodies.get(1) ?? []).toString("utf8")).toBe(html);
+    expect(Buffer.from(loaded.responseBodies.get(2) ?? []).toString("utf8")).toBe(json);
+    expect(Buffer.from(loaded.responseBodies.get(3) ?? []).toString("utf8")).toBe(text);
+    expect(Buffer.from(loaded.responseBodies.get(4) ?? [])).toEqual(Buffer.from(jpegBytes));
+  });
+
+  it("replaces the same credential with one fake value across url, headers, and bodies", async () => {
+    const secret = "super-secret-session";
+    const token = "query-token-abcdef";
+    fetchMock.mockResolvedValueOnce(
+      new Response(`welcome ${secret}`, {
+        status: 200,
+        headers: {
+          "content-type": "text/html",
+          "content-length": "28",
+          "set-cookie": `${secret}; Path=/`,
+        },
+      }),
+    );
+
+    const { recorder, stagingRoot, publishRoot } = await createRecorder();
+    await recorded(itemOne, Website.JAVDB, async () => {
+      await recorder.postText(`https://javdb.com/login?token=${token}`, `session=${secret}`, {
+        headers: { cookie: `session=${secret}` },
+      });
+    });
+
+    const loaded = await loadCrawlerCassette(stagingRoot, Website.JAVDB, "movie-one");
+    const cassetteText = JSON.stringify(loaded.cassette);
+    const body = Buffer.from(loaded.responseBodies.get(1) ?? []).toString("utf8");
+    expect(cassetteText).not.toContain(secret);
+    expect(cassetteText).not.toContain(token);
+    expect(body).not.toContain(secret);
+    expect(body).toContain("mdcz-test-cookie-session");
+    expect(loaded.cassette.interactions[0]?.request.url).toContain("mdcz-test-token-token");
+    expect(
+      loaded.cassette.interactions[0]?.request.headers.some(([, value]) => value.includes("mdcz-test-cookie-session")),
+    ).toBe(true);
+    expect(Buffer.from(loaded.cassette.interactions[0]?.request.bodyBase64 ?? "", "base64").toString("utf8")).toContain(
+      "mdcz-test-cookie-session",
+    );
+    expect(loaded.cassette.credentialSeed.cookies.session).toBe("mdcz-test-cookie-session");
+    expect(loaded.cassette.credentialSeed.tokens.token).toBe("mdcz-test-token-token");
+    expect(
+      loaded.cassette.interactions[0]?.response?.headers.some(
+        ([name, value]) => name === "content-length" && value === "32",
+      ),
+    ).toBe(true);
+
+    await recorder.finalize();
+    const published = await loadCrawlerCassette(publishRoot, Website.JAVDB, "movie-one");
+    expect(published.cassette.caseId).toBe("movie-one");
+  });
+
+  it("replays a recorded cassette without public network fallback", async () => {
+    fetchMock.mockResolvedValue(
+      new Response("<html>ok</html>", { status: 200, headers: { "content-type": "text/html" } }),
+    );
+    const { recorder, stagingRoot } = await createRecorder();
+    await recorded(itemOne, Website.DMM, async () => await recorder.getText("https://www.dmm.co.jp/detail"));
+
+    const replay = new CrawlerReplayNetworkClient({ fixturesRoot: stagingRoot });
+    await expect(
+      recorded(itemOne, Website.DMM, async () => await replay.getText("https://www.dmm.co.jp/detail")),
+    ).resolves.toBe("<html>ok</html>");
+    await replay.assertConsumed({ caseId: "movie-one", websites: [Website.DMM] });
+    await expect(replay.getText("https://www.dmm.co.jp/detail")).rejects.toThrow(
+      /public network fallback is disabled/u,
+    );
+  });
+
+  it("records transport errors and keeps request order for repeated urls", async () => {
+    fetchMock
+      .mockRejectedValueOnce(Object.assign(new Error("socket hang up"), { name: "FetchError" }))
+      .mockResolvedValueOnce(new Response("retry-ok", { status: 200, headers: { "content-type": "text/plain" } }));
+    const { stagingRoot } = await createRecorder();
+    const noRetry = new CrawlerRecordNetworkClient({
+      stagingRoot,
+      publishRoot: await tempDir("record-publish-retry"),
+      plan: PLAN,
+      network: { getRetryCount: () => 0 },
+    });
+
+    await expect(
+      recorded(itemOne, Website.DMM, async () => await noRetry.getText("https://www.dmm.co.jp/same")),
+    ).rejects.toThrow("socket hang up");
+    await expect(
+      recorded(itemOne, Website.DMM, async () => await noRetry.getText("https://www.dmm.co.jp/same")),
+    ).resolves.toBe("retry-ok");
+
+    const loaded = await loadCrawlerCassette(stagingRoot, Website.DMM, "movie-one");
+    expect(loaded.cassette.interactions).toHaveLength(2);
+    expect(loaded.cassette.interactions[0]?.transportError).toEqual({ name: "FetchError", message: "socket hang up" });
+    expect(loaded.cassette.interactions[1]?.response?.bodyPath).toBe("responses/002.txt");
+  });
+});

--- a/packages/runtime/src/network/CrawlerRecordNetworkClient.ts
+++ b/packages/runtime/src/network/CrawlerRecordNetworkClient.ts
@@ -1,0 +1,337 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { atomicWriteFile } from "@mdcz/media-store";
+import type { Website } from "@mdcz/shared/enums";
+import {
+  type CrawlerCassette,
+  type CrawlerCassetteInteraction,
+  headersToCassetteList,
+  rawRequestBodyToBase64,
+  resolveCrawlerCassetteDirectory,
+  responseBodyExtension,
+  sha256Hex,
+} from "./crawlerCassette";
+import { CrawlerCredentialRedactor } from "./crawlerCredentials";
+import { getCrawlerFixtureContext } from "./crawlerFixtureContext";
+import { type CrawlerRecordingPlan, caseIdForRecordingPath, loadCrawlerRecordingPlan } from "./crawlerRecordingPlan";
+import { type CrawlerRecordingObservation, publishCrawlerRecordingStaging } from "./crawlerRecordingPublish";
+import {
+  NetworkClient,
+  type NetworkClientOptions,
+  type RawNetworkRequest,
+  type RawNetworkResponse,
+} from "./NetworkClient";
+
+export interface CrawlerRecordNetworkClientOptions {
+  stagingRoot: string;
+  publishRoot: string;
+  plan: CrawlerRecordingPlan;
+  network?: Omit<NetworkClientOptions, "rawDispatch">;
+}
+
+interface SessionState {
+  website: Website;
+  caseId: string;
+  relativePath: string;
+  nextSequence: number;
+  interactions: Map<number, CrawlerCassetteInteraction>;
+  observedReals: Set<string>;
+  writeChain: Promise<void>;
+}
+
+const sessionKey = (website: Website, caseId: string): string => `${website}\u0000${caseId}`;
+
+const paddedSequence = (sequence: number): string => String(sequence).padStart(3, "0");
+
+const captureResponseBytes = async (response: RawNetworkResponse): Promise<Uint8Array> => {
+  const cloned = response.clone();
+  return new Uint8Array(await cloned.arrayBuffer());
+};
+
+export class CrawlerRecordNetworkClient extends NetworkClient {
+  private readonly stagingRoot: string;
+  private readonly publishRoot: string;
+  private readonly plan: CrawlerRecordingPlan;
+  private readonly redactor = new CrawlerCredentialRedactor();
+  private readonly sessions = new Map<string, SessionState>();
+  private readonly sequenceLocks = new Map<string, Promise<void>>();
+
+  constructor(options: CrawlerRecordNetworkClientOptions) {
+    super({
+      ...options.network,
+      rawDispatch: async (request, dispatch) => await this.dispatchAndRecord(request, dispatch),
+    });
+    this.stagingRoot = path.resolve(options.stagingRoot);
+    this.publishRoot = path.resolve(options.publishRoot);
+    this.plan = options.plan;
+  }
+
+  observations(): CrawlerRecordingObservation[] {
+    return [...this.sessions.values()].map((session) => ({
+      relativePath: session.relativePath,
+      caseId: session.caseId,
+      website: session.website,
+    }));
+  }
+
+  async finalize(): Promise<void> {
+    await Promise.all([...this.sessions.values()].map(async (session) => await session.writeChain));
+    await publishCrawlerRecordingStaging({
+      stagingRoot: this.stagingRoot,
+      publishRoot: this.publishRoot,
+      plan: this.plan,
+      observations: this.observations(),
+      redactor: this.redactor,
+    });
+  }
+
+  private async dispatchAndRecord(
+    request: RawNetworkRequest,
+    dispatch: () => Promise<RawNetworkResponse>,
+  ): Promise<RawNetworkResponse> {
+    const context = getCrawlerFixtureContext();
+    if (!context) return await dispatch();
+
+    const { website } = context.source;
+    const { caseId, relativePath } = context.item;
+    const plannedCaseId = caseIdForRecordingPath(this.plan, relativePath);
+    if (plannedCaseId !== caseId) {
+      throw new Error(`Recording plan caseId mismatch for ${relativePath}: expected ${plannedCaseId}, got ${caseId}`);
+    }
+
+    const key = sessionKey(website, caseId);
+    const sequence = await this.allocateSequence(key, website, caseId, relativePath);
+    try {
+      const response = await dispatch();
+      const bytes = await captureResponseBytes(response);
+      await this.recordInteraction(key, sequence, request, { response, bytes });
+      return response;
+    } catch (error) {
+      await this.recordInteraction(key, sequence, request, { error });
+      throw error;
+    }
+  }
+
+  private async allocateSequence(key: string, website: Website, caseId: string, relativePath: string): Promise<number> {
+    const previous = this.sequenceLocks.get(key) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.sequenceLocks.set(
+      key,
+      previous.then(() => current),
+    );
+    await previous;
+    try {
+      const session = this.getSession(key, website, caseId, relativePath);
+      session.nextSequence += 1;
+      return session.nextSequence;
+    } finally {
+      release();
+    }
+  }
+
+  private getSession(key: string, website: Website, caseId: string, relativePath: string): SessionState {
+    const existing = this.sessions.get(key);
+    if (existing) {
+      if (existing.relativePath !== relativePath) {
+        throw new Error(
+          `Crawler recording caseId ${caseId} is already bound to ${existing.relativePath}, not ${relativePath}`,
+        );
+      }
+      return existing;
+    }
+    const session: SessionState = {
+      website,
+      caseId,
+      relativePath,
+      nextSequence: 0,
+      interactions: new Map(),
+      observedReals: new Set(),
+      writeChain: Promise.resolve(),
+    };
+    this.sessions.set(key, session);
+    return session;
+  }
+
+  private async recordInteraction(
+    key: string,
+    sequence: number,
+    request: RawNetworkRequest,
+    outcome: { response: RawNetworkResponse; bytes: Uint8Array } | { error: unknown },
+  ): Promise<void> {
+    const session = this.sessions.get(key);
+    if (!session) throw new Error(`Crawler recording session is missing for ${key}`);
+
+    this.redactor.observeUrl(request.url);
+    this.redactor.observeHeaders(request.init.headers);
+    const requestBodyBytes = await this.requestBodyBytes(request);
+    if ("response" in outcome) this.redactor.observeHeaders(outcome.response.headers);
+
+    const inspect = this.inspectionText(request, requestBodyBytes, outcome);
+    for (const secret of this.redactor.secrets()) {
+      if (inspect.includes(secret.real)) session.observedReals.add(secret.real);
+    }
+
+    const redactedUrl = this.redactor.redactString(request.url);
+    const redactedRequestHeaders = this.redactHeaders(request.init.headers);
+    const redactedRequestBody = requestBodyBytes ? this.redactor.redactBytes(requestBodyBytes) : null;
+    const interaction: CrawlerCassetteInteraction = {
+      sequence,
+      request: {
+        method: (request.init.method ?? "GET").toUpperCase(),
+        url: redactedUrl,
+        headers: headersToCassetteList(redactedRequestHeaders),
+        bodyBase64: redactedRequestBody ? Buffer.from(redactedRequestBody).toString("base64") : null,
+      },
+    };
+
+    if ("error" in outcome) {
+      const error = outcome.error;
+      const name = error instanceof Error ? error.name : "Error";
+      const message = error instanceof Error ? error.message : String(error);
+      interaction.transportError = {
+        name: this.redactor.redactString(name),
+        message: this.redactor.redactString(message),
+      };
+    } else {
+      const redactedHeaders = this.redactHeaders(outcome.response.headers);
+      const redactedBody = this.redactor.redactBytes(outcome.bytes);
+      if (redactedBody.byteLength !== outcome.bytes.byteLength && redactedHeaders.has("content-length")) {
+        redactedHeaders.set("content-length", String(redactedBody.byteLength));
+      }
+      const extension = responseBodyExtension(outcome.response.headers.get("content-type"));
+      const bodyPath = path.posix.join("responses", `${paddedSequence(sequence)}${extension}`);
+      const directory = resolveCrawlerCassetteDirectory(this.stagingRoot, session.website, session.caseId);
+      await mkdir(path.join(directory, "responses"), { recursive: true });
+      await atomicWriteFile(path.join(directory, bodyPath), redactedBody);
+      interaction.response = {
+        status: outcome.response.status,
+        statusText: outcome.response.statusText,
+        url: this.redactor.redactString(outcome.response.url || request.url),
+        headers: headersToCassetteList(redactedHeaders),
+        bodyPath,
+        sha256: sha256Hex(redactedBody),
+      };
+    }
+
+    session.interactions.set(sequence, interaction);
+    session.writeChain = session.writeChain.then(async () => await this.writeCassette(session));
+    await session.writeChain;
+  }
+
+  private inspectionText(
+    request: RawNetworkRequest,
+    requestBodyBytes: Uint8Array | null,
+    outcome: { response: RawNetworkResponse; bytes: Uint8Array } | { error: unknown },
+  ): string {
+    const headerText = headersToCassetteList(request.init.headers)
+      .map(([name, value]) => `${name}:${value}`)
+      .join("\n");
+    const parts = [request.url, headerText, requestBodyBytes ? Buffer.from(requestBodyBytes).toString("utf8") : ""];
+    if ("error" in outcome) {
+      parts.push(
+        outcome.error instanceof Error ? `${outcome.error.name}:${outcome.error.message}` : String(outcome.error),
+      );
+      return parts.join("\n");
+    }
+    const responseHeaders = headersToCassetteList(outcome.response.headers)
+      .map(([name, value]) => `${name}:${value}`)
+      .join("\n");
+    parts.push(outcome.response.url, responseHeaders, Buffer.from(outcome.bytes).toString("utf8"));
+    return parts.join("\n");
+  }
+
+  private redactHeaders(headers: Headers): Headers {
+    const redacted = new Headers();
+    for (const [name, value] of headersToCassetteList(headers)) {
+      redacted.append(name, this.redactor.redactString(value));
+    }
+    return redacted;
+  }
+
+  private async requestBodyBytes(request: RawNetworkRequest): Promise<Uint8Array | null> {
+    const encoded = await rawRequestBodyToBase64(request.init.body);
+    return encoded ? new Uint8Array(Buffer.from(encoded, "base64")) : null;
+  }
+
+  private async writeCassette(session: SessionState): Promise<void> {
+    const interactions = [...session.interactions.entries()]
+      .sort(([left], [right]) => left - right)
+      .map(([, interaction]) => interaction);
+    const cassette: CrawlerCassette = {
+      schemaVersion: 1,
+      caseId: session.caseId,
+      website: session.website,
+      credentialSeed: this.redactor.seed(session.observedReals),
+      interactions,
+    };
+    const directory = resolveCrawlerCassetteDirectory(this.stagingRoot, session.website, session.caseId);
+    await mkdir(directory, { recursive: true });
+    await atomicWriteFile(path.join(directory, "cassette.json"), `${JSON.stringify(cassette, null, 2)}\n`);
+  }
+}
+
+const DEFAULT_STAGING_ROOT = "test-results/recording/staging";
+const DEFAULT_PUBLISH_ROOT = "tests/fixtures/crawler";
+
+interface ResolvedRecordingSettings {
+  plan: CrawlerRecordingPlan;
+  stagingRoot: string;
+  publishRoot: string;
+}
+
+let envSettings: ResolvedRecordingSettings | undefined;
+let envSettingsResolved = false;
+let envRecorder: CrawlerRecordNetworkClient | undefined;
+
+const envFlagEnabled = (value: string | undefined): boolean => {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+};
+
+export const resolveCrawlerRecordingSettingsFromEnv = (
+  env: NodeJS.ProcessEnv = process.env,
+): ResolvedRecordingSettings | undefined => {
+  if (!envFlagEnabled(env.MDCZ_RECORD_CRAWLER)) return undefined;
+  const planPath = env.MDCZ_RECORD_PLAN?.trim();
+  if (!planPath) throw new Error("MDCZ_RECORD_PLAN is required when MDCZ_RECORD_CRAWLER is enabled");
+  return {
+    plan: loadCrawlerRecordingPlan(planPath),
+    stagingRoot: env.MDCZ_RECORD_STAGING?.trim() || DEFAULT_STAGING_ROOT,
+    publishRoot: env.MDCZ_RECORD_PUBLISH?.trim() || DEFAULT_PUBLISH_ROOT,
+  };
+};
+
+const cachedRecordingSettings = (): ResolvedRecordingSettings | undefined => {
+  if (!envSettingsResolved) {
+    envSettingsResolved = true;
+    envSettings = resolveCrawlerRecordingSettingsFromEnv();
+  }
+  return envSettings;
+};
+
+export const createCrawlerNetworkClient = (
+  options: NetworkClientOptions = {},
+  env: NodeJS.ProcessEnv = process.env,
+): NetworkClient => {
+  const settings = env === process.env ? cachedRecordingSettings() : resolveCrawlerRecordingSettingsFromEnv(env);
+  if (!settings) return new NetworkClient(options);
+  if (env === process.env) envSettings = settings;
+  const recorder = new CrawlerRecordNetworkClient({ ...settings, network: options });
+  envRecorder = recorder;
+  return recorder;
+};
+
+export const attachCrawlerRecordingCaseId = <T extends { relativePath: string; caseId?: string }>(item: T): T => {
+  const settings = cachedRecordingSettings();
+  if (!settings) return item;
+  const caseId = caseIdForRecordingPath(settings.plan, item.relativePath);
+  if (!caseId) throw new Error(`Recording plan has no caseId for ${item.relativePath}`);
+  return { ...item, caseId };
+};
+
+export const finalizeCrawlerRecording = async (): Promise<void> => {
+  await envRecorder?.finalize();
+};

--- a/packages/runtime/src/network/NetworkClient.ts
+++ b/packages/runtime/src/network/NetworkClient.ts
@@ -7,6 +7,7 @@ import { createAbortError, isAbortError } from "../scrape/utils/abort";
 import { parseImageDimensions } from "../scrape/utils/image";
 import { runtimeLoggerService } from "../shared";
 import { parseRetryAfterMs } from "../shared/utils";
+import { preserveScrapeExecutionContext } from "./crawlerFixtureContext";
 import { RateLimiter } from "./RateLimiter";
 
 const RETRY_STATUS_CODE = 429;
@@ -460,7 +461,7 @@ export class NetworkClient implements SiteRequestConfigRegistrar {
   ): Promise<TResult> {
     return this.rateLimiter.schedule(
       url,
-      async () => {
+      preserveScrapeExecutionContext(async () => {
         if (init.signal?.aborted) {
           throw createAbortError();
         }
@@ -515,7 +516,7 @@ export class NetworkClient implements SiteRequestConfigRegistrar {
             await retryTransportError(error);
           }
         }
-      },
+      }),
       init.signal,
     );
   }

--- a/packages/runtime/src/network/crawlerCassette.ts
+++ b/packages/runtime/src/network/crawlerCassette.ts
@@ -59,10 +59,30 @@ export interface LoadedCrawlerCassette {
   responseBodies: ReadonlyMap<number, Uint8Array>;
 }
 
-const assertPathSegment = (label: string, value: string): void => {
+export const assertCrawlerFixturePathSegment = (label: string, value: string): void => {
   if (!/^[a-z0-9][a-z0-9._-]*$/iu.test(value)) {
     throw new Error(`${label} must be a single filesystem-safe path segment: ${value}`);
   }
+};
+
+export const resolveCrawlerCassetteDirectory = (fixturesRoot: string, website: Website, caseId: string): string => {
+  assertCrawlerFixturePathSegment("Website", website);
+  assertCrawlerFixturePathSegment("Crawler fixture caseId", caseId);
+  return path.resolve(fixturesRoot, website, caseId);
+};
+
+export const responseBodyExtension = (contentType: string | null): string => {
+  const type = (contentType ?? "").split(";")[0]?.trim().toLowerCase() ?? "";
+  if (type.includes("html")) return ".html";
+  if (type.includes("json")) return ".json";
+  if (type.startsWith("text/")) return ".txt";
+  if (type === "image/jpeg" || type === "image/jpg") return ".jpg";
+  if (type === "image/png") return ".png";
+  if (type === "image/gif") return ".gif";
+  if (type === "image/webp") return ".webp";
+  if (type === "image/avif") return ".avif";
+  if (type === "image/bmp") return ".bmp";
+  return ".bin";
 };
 
 const resolveResponsePath = (directory: string, bodyPath: string): string => {
@@ -105,9 +125,7 @@ export const loadCrawlerCassette = async (
   website: Website,
   caseId: string,
 ): Promise<LoadedCrawlerCassette> => {
-  assertPathSegment("Website", website);
-  assertPathSegment("Crawler fixture caseId", caseId);
-  const directory = path.resolve(fixturesRoot, website, caseId);
+  const directory = resolveCrawlerCassetteDirectory(fixturesRoot, website, caseId);
   const cassettePath = path.join(directory, "cassette.json");
   const cassette = crawlerCassetteSchema.parse(JSON.parse(await readFile(cassettePath, "utf8")));
 

--- a/packages/runtime/src/network/crawlerCredentials.ts
+++ b/packages/runtime/src/network/crawlerCredentials.ts
@@ -1,0 +1,135 @@
+import type { CrawlerCredentialSeed } from "./crawlerCassette";
+
+const MIN_SECRET_LENGTH = 8;
+const TOKEN_QUERY_NAME = /token|csrf|auth|session|secret|password|passwd|access_key|api_key/iu;
+
+export interface ObservedCredential {
+  name: string;
+  kind: "cookie" | "token";
+  real: string;
+  fake: string;
+}
+
+const sanitizeName = (name: string): string => {
+  const normalized = name
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9._-]+/gu, "-");
+  return normalized || "value";
+};
+
+const replaceAllBytes = (haystack: Uint8Array, needle: Uint8Array, replacement: Uint8Array): Uint8Array => {
+  if (needle.byteLength === 0) return haystack;
+  const source = Buffer.from(haystack);
+  const from = Buffer.from(needle);
+  const to = Buffer.from(replacement);
+  const parts: Buffer[] = [];
+  let start = 0;
+  while (true) {
+    const index = source.indexOf(from, start);
+    if (index === -1) {
+      parts.push(source.subarray(start));
+      break;
+    }
+    parts.push(source.subarray(start, index), to);
+    start = index + from.length;
+  }
+  return new Uint8Array(Buffer.concat(parts));
+};
+
+export class CrawlerCredentialRedactor {
+  private readonly byReal = new Map<string, ObservedCredential>();
+  private readonly fakeNames = new Set<string>();
+
+  register(name: string, real: string, kind: "cookie" | "token"): void {
+    const value = real.trim();
+    if (value.length < MIN_SECRET_LENGTH || this.byReal.has(value)) return;
+
+    let fake = `mdcz-test-${kind}-${sanitizeName(name)}`;
+    if (this.fakeNames.has(fake) || [...this.byReal.values()].some((entry) => entry.fake === fake)) {
+      fake = `${fake}-${this.byReal.size + 1}`;
+    }
+    this.fakeNames.add(fake);
+    this.byReal.set(value, { name: name.trim() || kind, kind, real: value, fake });
+  }
+
+  observeUrl(url: string): void {
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      return;
+    }
+    for (const [name, value] of parsed.searchParams) {
+      if (TOKEN_QUERY_NAME.test(name)) this.register(name, value, "token");
+    }
+  }
+
+  observeHeaders(headers: Headers): void {
+    const cookie = headers.get("cookie");
+    if (cookie) {
+      for (const part of cookie.split(";")) {
+        const separator = part.indexOf("=");
+        if (separator <= 0) continue;
+        this.register(part.slice(0, separator).trim(), part.slice(separator + 1).trim(), "cookie");
+      }
+    }
+
+    const authorization = headers.get("authorization");
+    if (authorization) {
+      const bearer = authorization.match(/^Bearer\s+(\S+)/u);
+      this.register("authorization", bearer?.[1] ?? authorization, "token");
+    }
+
+    const csrf = headers.get("x-csrf-token") ?? headers.get("x-xsrf-token");
+    if (csrf) this.register("csrf", csrf, "token");
+
+    const setCookies = (headers as Headers & { getSetCookie?: () => string[] }).getSetCookie?.() ?? [];
+    for (const header of setCookies) {
+      const pair = header.split(";", 1)[0] ?? "";
+      const separator = pair.indexOf("=");
+      if (separator <= 0) continue;
+      this.register(pair.slice(0, separator).trim(), pair.slice(separator + 1).trim(), "cookie");
+    }
+  }
+
+  redactString(value: string): string {
+    let result = value;
+    for (const secret of this.secretsLongestFirst()) {
+      result = result.split(secret.real).join(secret.fake);
+    }
+    return result;
+  }
+
+  redactBytes(bytes: Uint8Array): Uint8Array {
+    let result = bytes;
+    for (const secret of this.secretsLongestFirst()) {
+      result = replaceAllBytes(result, Buffer.from(secret.real, "utf8"), Buffer.from(secret.fake, "utf8"));
+    }
+    return result;
+  }
+
+  containsRealSecret(value: string | Uint8Array): boolean {
+    const text = typeof value === "string" ? value : Buffer.from(value).toString("utf8");
+    return this.secrets().some((secret) => text.includes(secret.real));
+  }
+
+  seed(reals = new Set(this.byReal.keys())): CrawlerCredentialSeed {
+    const cookies: Record<string, string> = {};
+    const tokens: Record<string, string> = {};
+    for (const secret of this.secrets()) {
+      if (!reals.has(secret.real)) continue;
+      if (secret.kind === "cookie") cookies[secret.name] = secret.fake;
+      else tokens[secret.name] = secret.fake;
+    }
+    return { cookies, tokens };
+  }
+
+  secrets(): ObservedCredential[] {
+    return [...this.byReal.values()];
+  }
+
+  private secretsLongestFirst(): ObservedCredential[] {
+    return this.secrets().sort((left, right) => right.real.length - left.real.length);
+  }
+}

--- a/packages/runtime/src/network/crawlerFixtureContext.ts
+++ b/packages/runtime/src/network/crawlerFixtureContext.ts
@@ -23,6 +23,12 @@ interface ScrapeExecutionContext {
 
 const scrapeExecutionStorage = new AsyncLocalStorage<ScrapeExecutionContext>();
 
+export const preserveScrapeExecutionContext = <T extends () => unknown>(run: T): T => {
+  const store = scrapeExecutionStorage.getStore();
+  if (!store) return run;
+  return (() => scrapeExecutionStorage.run(store, run)) as T;
+};
+
 export const runWithScrapeItemContext = async <T>(context: ScrapeItemContext, run: () => Promise<T>): Promise<T> => {
   const item = { ...context, active: true };
   try {

--- a/packages/runtime/src/network/crawlerRecordingPlan.ts
+++ b/packages/runtime/src/network/crawlerRecordingPlan.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { z } from "zod";
+import { assertCrawlerFixturePathSegment } from "./crawlerCassette";
+
+const recordingItemSchema = z.object({
+  relativePath: z.string().min(1),
+  caseId: z.string().min(1),
+});
+
+export const crawlerRecordingPlanSchema = z.object({
+  journeyId: z.string().min(1),
+  items: z.array(recordingItemSchema).min(1),
+});
+
+export type CrawlerRecordingPlan = z.infer<typeof crawlerRecordingPlanSchema>;
+
+const normalizeRelativePath = (relativePath: string): string => relativePath.replaceAll("\\", "/");
+
+export const caseIdForRecordingPath = (plan: CrawlerRecordingPlan, relativePath: string): string | undefined => {
+  const normalized = normalizeRelativePath(relativePath);
+  const exact = plan.items.find((item) => normalizeRelativePath(item.relativePath) === normalized);
+  if (exact) return exact.caseId;
+
+  const base = path.posix.basename(normalized);
+  const basenameMatches = plan.items.filter(
+    (item) => path.posix.basename(normalizeRelativePath(item.relativePath)) === base,
+  );
+  if (basenameMatches.length === 1) return basenameMatches[0]?.caseId;
+  if (basenameMatches.length > 1) {
+    throw new Error(`Recording plan has ambiguous caseId mapping for ${relativePath}`);
+  }
+  return undefined;
+};
+
+export const loadCrawlerRecordingPlan = (planPath: string): CrawlerRecordingPlan => {
+  const plan = crawlerRecordingPlanSchema.parse(JSON.parse(readFileSync(planPath, "utf8")));
+  for (const item of plan.items) {
+    assertCrawlerFixturePathSegment("Crawler fixture caseId", item.caseId);
+  }
+  return plan;
+};

--- a/packages/runtime/src/network/crawlerRecordingPublish.ts
+++ b/packages/runtime/src/network/crawlerRecordingPublish.ts
@@ -1,0 +1,151 @@
+import { cp, readdir, readFile, rm } from "node:fs/promises";
+import path from "node:path";
+import { Website } from "@mdcz/shared/enums";
+import {
+  type CrawlerCassette,
+  crawlerCassetteSchema,
+  loadCrawlerCassette,
+  resolveCrawlerCassetteDirectory,
+} from "./crawlerCassette";
+import type { CrawlerCredentialRedactor } from "./crawlerCredentials";
+import { type CrawlerRecordingPlan, caseIdForRecordingPath } from "./crawlerRecordingPlan";
+
+export interface CrawlerRecordingObservation {
+  relativePath: string;
+  caseId: string;
+  website: Website;
+}
+
+const websiteValues = new Set<string>(Object.values(Website));
+
+const listCassetteDirectories = async (
+  root: string,
+): Promise<Array<{ website: string; caseId: string; directory: string }>> => {
+  const entries: Array<{ website: string; caseId: string; directory: string }> = [];
+  let websites: string[];
+  try {
+    websites = await readdir(root);
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return [];
+    throw error;
+  }
+
+  for (const website of websites) {
+    const websiteDir = path.join(root, website);
+    const cases = await readdir(websiteDir, { withFileTypes: true });
+    for (const entry of cases) {
+      if (!entry.isDirectory()) continue;
+      entries.push({ website, caseId: entry.name, directory: path.join(websiteDir, entry.name) });
+    }
+  }
+  return entries;
+};
+
+const scanForResidualSecrets = async (directory: string, redactor: CrawlerCredentialRedactor): Promise<string[]> => {
+  const residual: string[] = [];
+  const walk = async (current: string): Promise<void> => {
+    const entries = await readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const target = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        await walk(target);
+        continue;
+      }
+      const bytes = await readFile(target);
+      if (redactor.containsRealSecret(bytes)) residual.push(path.relative(directory, target));
+    }
+  };
+  await walk(directory);
+  return residual;
+};
+
+export const validateCrawlerRecordingStaging = async (options: {
+  stagingRoot: string;
+  plan: CrawlerRecordingPlan;
+  observations: readonly CrawlerRecordingObservation[];
+  redactor?: CrawlerCredentialRedactor;
+}): Promise<CrawlerCassette[]> => {
+  const unmapped = options.observations.filter(
+    (observation) => caseIdForRecordingPath(options.plan, observation.relativePath) !== observation.caseId,
+  );
+  if (unmapped.length > 0) {
+    throw new Error(
+      `Recording items are missing a plan caseId: ${unmapped.map((item) => item.relativePath).join(", ")}`,
+    );
+  }
+
+  const expected = new Map<string, CrawlerRecordingObservation>();
+  for (const observation of options.observations) {
+    expected.set(`${observation.website}\u0000${observation.caseId}`, observation);
+  }
+
+  const staged = await listCassetteDirectories(options.stagingRoot);
+  const cassettes: CrawlerCassette[] = [];
+  for (const entry of staged) {
+    if (!websiteValues.has(entry.website)) {
+      throw new Error(`Recording staging contains an unknown website directory: ${entry.website}`);
+    }
+    const website = entry.website as Website;
+    const loaded = await loadCrawlerCassette(options.stagingRoot, website, entry.caseId);
+    if (loaded.cassette.website !== website) {
+      throw new Error(`Crawler cassette crossed website directories at ${entry.directory}`);
+    }
+    if (loaded.cassette.interactions.length === 0) {
+      throw new Error(`Crawler cassette has no interactions at ${website}/${entry.caseId}`);
+    }
+    if (options.redactor) {
+      const residual = await scanForResidualSecrets(entry.directory, options.redactor);
+      if (residual.length > 0) {
+        throw new Error(
+          `Crawler cassette leaked real credentials at ${website}/${entry.caseId}: ${residual.join(", ")}`,
+        );
+      }
+    }
+    expected.delete(`${website}\u0000${entry.caseId}`);
+    cassettes.push(crawlerCassetteSchema.parse(loaded.cassette));
+  }
+
+  if (expected.size > 0) {
+    const missing = [...expected.values()].map((item) => `${item.website}/${item.caseId}`).join(", ");
+    throw new Error(`Recording did not write cassettes for observed crawler sources: ${missing}`);
+  }
+
+  return cassettes;
+};
+
+export const observationsFromStagedCassettes = async (
+  stagingRoot: string,
+  plan: CrawlerRecordingPlan,
+): Promise<CrawlerRecordingObservation[]> => {
+  const staged = await listCassetteDirectories(stagingRoot);
+  const observations: CrawlerRecordingObservation[] = [];
+  for (const entry of staged) {
+    if (!websiteValues.has(entry.website)) {
+      throw new Error(`Recording staging contains an unknown website directory: ${entry.website}`);
+    }
+    const website = entry.website as Website;
+    const loaded = await loadCrawlerCassette(stagingRoot, website, entry.caseId);
+    const mapped = plan.items.find((item) => item.caseId === loaded.cassette.caseId);
+    if (!mapped) {
+      throw new Error(`Staged cassette ${website}/${entry.caseId} is not in the recording plan`);
+    }
+    observations.push({ relativePath: mapped.relativePath, caseId: entry.caseId, website });
+  }
+  return observations;
+};
+
+export const publishCrawlerRecordingStaging = async (options: {
+  stagingRoot: string;
+  publishRoot: string;
+  plan: CrawlerRecordingPlan;
+  observations: readonly CrawlerRecordingObservation[];
+  redactor?: CrawlerCredentialRedactor;
+}): Promise<void> => {
+  const cassettes = await validateCrawlerRecordingStaging(options);
+  for (const cassette of cassettes) {
+    const source = resolveCrawlerCassetteDirectory(options.stagingRoot, cassette.website, cassette.caseId);
+    const destination = resolveCrawlerCassetteDirectory(options.publishRoot, cassette.website, cassette.caseId);
+    await rm(destination, { recursive: true, force: true });
+    await cp(source, destination, { recursive: true });
+  }
+};

--- a/packages/runtime/src/network/index.ts
+++ b/packages/runtime/src/network/index.ts
@@ -182,11 +182,15 @@ export class FetchNetworkClient implements RuntimeNetworkClient {
   }
 }
 
+export * from "./CrawlerRecordNetworkClient";
 export * from "./CrawlerReplayNetworkClient";
 export * from "./cookieChecks";
 export * from "./cookieUtils";
 export * from "./crawlerCassette";
+export * from "./crawlerCredentials";
 export * from "./crawlerFixtureContext";
+export * from "./crawlerRecordingPlan";
+export * from "./crawlerRecordingPublish";
 export * from "./InMemoryCookieJar";
 export * from "./NetworkClient";
 export * from "./RateLimiter";

--- a/tests/recording/plans/representative-batch.json
+++ b/tests/recording/plans/representative-batch.json
@@ -1,0 +1,9 @@
+{
+  "journeyId": "representative-batch",
+  "items": [
+    {
+      "relativePath": "movie-file.mp4",
+      "caseId": "movie-case"
+    }
+  ]
+}

--- a/tests/recording/publish.mjs
+++ b/tests/recording/publish.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { loadCrawlerRecordingPlan } from "../../packages/runtime/src/network/crawlerRecordingPlan.ts";
+import {
+  observationsFromStagedCassettes,
+  publishCrawlerRecordingStaging,
+} from "../../packages/runtime/src/network/crawlerRecordingPublish.ts";
+
+const workspaceRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const args = process.argv.slice(2);
+const planIndex = args.indexOf("--plan");
+const planPath = path.resolve(
+  workspaceRoot,
+  process.env.MDCZ_RECORD_PLAN?.trim() ||
+    (planIndex >= 0 ? (args[planIndex + 1] ?? "") : "tests/recording/plans/representative-batch.json"),
+);
+const stagingRoot = path.resolve(
+  workspaceRoot,
+  process.env.MDCZ_RECORD_STAGING?.trim() || "test-results/recording/staging",
+);
+const publishRoot = path.resolve(workspaceRoot, process.env.MDCZ_RECORD_PUBLISH?.trim() || "tests/fixtures/crawler");
+
+const plan = loadCrawlerRecordingPlan(planPath);
+const observations = await observationsFromStagedCassettes(stagingRoot, plan);
+await publishCrawlerRecordingStaging({ stagingRoot, publishRoot, plan, observations });
+console.log(`Published ${observations.length} crawler cassette(s) to ${publishRoot}`);

--- a/tests/recording/run.mjs
+++ b/tests/recording/run.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { resolvePnpmCli } from "../e2e/runner-layout.ts";
+
+const workspaceRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const pnpmCli = resolvePnpmCli(process.env.npm_execpath);
+const args = process.argv.slice(2);
+const mode = args[0] === "desktop" || args[0] === "webui" ? args[0] : "webui";
+const rest = args[0] === "desktop" || args[0] === "webui" ? args.slice(1) : args;
+const planIndex = rest.indexOf("--plan");
+const planArg = planIndex >= 0 ? rest[planIndex + 1] : undefined;
+if (planIndex >= 0 && !planArg) throw new Error("record: --plan requires a path");
+
+const planPath = path.resolve(workspaceRoot, planArg ?? "tests/recording/plans/representative-batch.json");
+const env = {
+  ...process.env,
+  MDCZ_RECORD_CRAWLER: "1",
+  MDCZ_RECORD_PLAN: planPath,
+  MDCZ_RECORD_STAGING:
+    process.env.MDCZ_RECORD_STAGING?.trim() || path.join(workspaceRoot, "test-results/recording/staging"),
+  MDCZ_RECORD_PUBLISH: process.env.MDCZ_RECORD_PUBLISH?.trim() || path.join(workspaceRoot, "tests/fixtures/crawler"),
+};
+
+const run = (command, commandArgs) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(command, commandArgs, { cwd: workspaceRoot, env, stdio: "inherit" });
+    const shutdown = () => child.kill("SIGTERM");
+    process.once("SIGINT", shutdown);
+    process.once("SIGTERM", shutdown);
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      process.removeListener("SIGINT", shutdown);
+      process.removeListener("SIGTERM", shutdown);
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`${command} ${commandArgs.join(" ")} exited with ${code ?? signal}`));
+    });
+  });
+
+const runPnpm = (commandArgs) =>
+  /\.(?:c?js|mjs)$/iu.test(pnpmCli) ? run(process.execPath, [pnpmCli, ...commandArgs]) : run(pnpmCli, commandArgs);
+
+const waitForUrl = async (url, timeoutMs = 60_000) => {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(1_000) });
+      if (response.ok || response.status === 404) return;
+    } catch {
+      // Dev servers are still binding.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`Timed out waiting for ${url}`);
+};
+
+console.log(`Recording crawler fixtures with plan ${planPath}`);
+
+if (mode === "desktop") {
+  console.log("Desktop recording starts the real app. Scrape the planned items, then stop the process to publish.");
+  await runPnpm(["dev:desktop"]);
+} else {
+  const webui = spawn(
+    /\.(?:c?js|mjs)$/iu.test(pnpmCli) ? process.execPath : pnpmCli,
+    /\.(?:c?js|mjs)$/iu.test(pnpmCli) ? [pnpmCli, "dev:webui"] : ["dev:webui"],
+    { cwd: workspaceRoot, env, stdio: "inherit" },
+  );
+  const shutdownWebui = () => {
+    if (webui.exitCode === null) webui.kill("SIGTERM");
+  };
+  process.once("SIGINT", shutdownWebui);
+  process.once("SIGTERM", shutdownWebui);
+  try {
+    await waitForUrl("http://127.0.0.1:5173");
+    await runPnpm(["exec", "playwright", "codegen", "http://127.0.0.1:5173"]);
+  } finally {
+    shutdownWebui();
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

The previous `feat: add tests record` commit only landed the permanent replay substrate. This adds the missing recording path so an item × Website scrape can write raw crawler cassettes.

## How to start recording

1. Edit `tests/recording/plans/representative-batch.json` (or pass `--plan`) so each scraped file maps to a source-agnostic `caseId`.
2. Start a recording session:
   - Web: `pnpm record:webui -- --plan tests/recording/plans/representative-batch.json`
   - Desktop: `pnpm record:desktop -- --plan tests/recording/plans/representative-batch.json`
3. Select those files and run a real scrape. Only `crawlerProvider.crawl()` traffic is recorded; poster/thumb/translation/media-server requests are skipped.
4. Stop the app (fixtures are published on shutdown). If needed: `pnpm record:publish`.

Cassettes land at `tests/fixtures/crawler/<website>/<caseId>/` (`cassette.json` + `responses/`).

## Implementation

- `CrawlerRecordNetworkClient` intercepts `rawDispatch` when item + Website + caseId are active.
- Credentials are replaced with stable fakes in URL/headers/bodies; only the synthetic seed is stored.
- Staging is validated (plan mapping, per-Website isolation, hashes, no leftover secrets) then published.
- Desktop/Server scrape items receive `caseId` from the plan while `MDCZ_RECORD_CRAWLER=1`.
- Rate-limiter queues now preserve scrape ALS context so delayed same-domain requests still record/replay.

Recorder, redactor, staging, and `pnpm record:*` scripts are the temporary recording-period tools from the plan; they can be stashed after fixtures exist.

## Tests

- Recorder unit tests: multi-item caseId split, concurrent DMM/JavDB/JavBus isolation, no recording outside crawler context, HTML/JSON/text/binary bytes + extensions, consistent credential fakes, transport errors, replay round-trip.
- `pnpm typecheck` and `pnpm test:unit` passed (679 tests).

Playwright journey specs, per-crawler cassette consumption tests, and actual recorded fixtures are still follow-up work after a live recording session.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6321b6ca-7601-42ea-8ee5-ae79d19dbeb7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6321b6ca-7601-42ea-8ee5-ae79d19dbeb7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

